### PR TITLE
No need to explicitly exclude vendor with Go 1.9+.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ADD app /go/src/github.com/umputun/remark/app
 ADD vendor /go/src/github.com/umputun/remark/vendor
 ADD .git /go/src/github.com/umputun/remark/.git
 
-RUN cd app && go test $(go list -e ./... | grep -v vendor)
+RUN cd app && go test ./...
 
 RUN gometalinter --disable-all --deadline=300s --vendor --enable=vet --enable=vetshadow --enable=golint \
     --enable=staticcheck --enable=ineffassign --enable=goconst --enable=errcheck --enable=unconvert \


### PR DESCRIPTION
https://golang.org/doc/go1.9#vendor-dotdotdot