### PR TITLE
feature/ts - read-only support 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ install:
 script:
   - docker build
       --build-arg COVERALLS_TOKEN=$COVERALLS_TOKEN
-      --build-arg CODECOV_TOKEN=$CODECOV_TOKEN
       --build-arg CI=$CI
       --build-arg TRAVIS=$TRAVIS
       --build-arg TRAVIS_BRANCH=$TRAVIS_BRANCH

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,10 +51,11 @@ WORKDIR /srv
 ADD scripts/import-disqus.sh /srv/import-disqus.sh
 ADD scripts/restore-backup.sh /srv/restore-backup.sh
 ADD scripts/migrate-data.sh /srv/migrate-data.sh
+ADD scripts/create-backup.sh /srv/create-backup.sh
 
 ADD start.sh /srv/start.sh
 
-RUN chmod +x /srv/start.sh /srv/import-disqus.sh /srv/restore-backup.sh /srv/migrate-data.sh
+RUN chmod +x /srv/start.sh /srv/import-disqus.sh /srv/restore-backup.sh /srv/migrate-data.sh /srv/create-backup.sh
 
 COPY --from=build-backend /go/src/github.com/umputun/remark/remark /srv/
 COPY --from=build-frontend /srv/web/public/ /srv/web

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,10 +50,11 @@ WORKDIR /srv
 
 ADD scripts/import-disqus.sh /srv/import-disqus.sh
 ADD scripts/restore-backup.sh /srv/restore-backup.sh
+ADD scripts/migrate-data.sh /srv/migrate-data.sh
 
 ADD start.sh /srv/start.sh
 
-RUN chmod +x /srv/start.sh /srv/import-disqus.sh /srv/restore-backup.sh
+RUN chmod +x /srv/start.sh /srv/import-disqus.sh /srv/restore-backup.sh /srv/migrate-data.sh
 
 COPY --from=build-backend /go/src/github.com/umputun/remark/remark /srv/
 COPY --from=build-frontend /srv/web/public/ /srv/web

--- a/README.md
+++ b/README.md
@@ -33,13 +33,14 @@ Remark42 is a self-hosted, lightweight, and simple (yet functional) comment engi
 | Command line      | Environment          | Default                | Multi | Description                             |
 | ----------------- | -------------------- | ---------------------- | ----- | --------------------------------------- |
 | --url             | REMARK_URL           | `https://remark42.com` | no    | url to remark server                    |
-| --bolt            | BOLTDB_PATH          | `/tmp`                 | no    | path to data directory                  |
+| --bolt            | BOLTDB_PATH          | `./var`                | no    | path to data directory                  |
 | --site            | SITE                 | `remark`               | yes   | site name(s)                            |
 | --admin           | ADMIN                |                        | yes   | admin names (list of user ids)          |
-| --backup          | BACKUP_PATH          | `/tmp`                 | no    | backups location                        |
+| --backup          | BACKUP_PATH          | `./var/backup`         | no    | backups location                        |
 | --max-back        | MAX_BACKUP_FILES     | `10`                   | no    | max backup files to keep                |
 | --max-cache-items | MAX_CACHE_ITEMS      | `1000`                 | no    | max number of cached items, 0-unlimited |
 | --max-cache-value | MAX_CACHE_VALUE      | `65536`                | no    | max size of cached value, o-unlimited   |
+| --avatars         | AVATAR_STORE         | `./var/avatars`        | no    | avatars location                        |
 | --secret          | SECRET               |                        | no    | secret key, required                    |
 | --max-comment     | MAX_COMMENT_SIZE     | 2048                   | no    | comment's size limit                    |
 | --google-cid      | REMARK_GOOGLE_CID    |                        | no    | Google OAuth client ID                  |
@@ -103,6 +104,26 @@ _instructions for google oauth2 setup borrowed from [oauth2_proxy](https://githu
 1.  Disqus provides an export of all comments on your site in a g-zipped file. This is found in your Moderation panel at Disqus Admin > Setup > Export. The export will be sent into a queue and then emailed to the address associated with your account once it's ready. Direct link to export will be something like `https://<siteud>.disqus.com/admin/discussions/export/`. See [importing-exporting](https://help.disqus.com/customer/portal/articles/1104797-importing-exporting) for more details.
 2.  Move this file to your remark42 host within `.var` and unzip, i.e. `gunzip <disqus-export-name>.xml.gz`.
 3.  Run import command - `docker-compose exec remark /srv/import-disqus.sh <disqus-export-name>.xml <your site id>`
+
+#### Backup and restore
+
+##### Automatic backups
+Remark42 by default makes daily backup files under `${BACKUP_PATH}` (default `./var/backup`). Backups kept up to `${MAX_BACKUP_FILES}` (default 10). Each backup file contains exported and gzipped content, i.e., all comments. At any point, the user can restore such backup and revert all comments to the desirable state. Note: restore procedure cleans the current data store and replaces all comments with comments from the backup file.
+
+For safety and security reasons restore functionality not exposed outside of your server by default. The recommended way to restore from the backup is to use provided `scripts/restore-backup.sh`. It can run inside the container:
+
+`docker-compose exec remark /srv/restore-backup.sh <backup-filename.gz> <your site id>`
+
+##### Schema migration
+
+One special case for backup/restore is schema migration. Some versions or remark42 may extend or change the schema 
+and for such upgrades migration required. Provided migration script `scripts/migrate-data.sh` makes a fresh backup and then loads it back to your remark42 instance.
+
+`docker-compose exec remark /srv/migrate-data.sh <your site id>`
+
+##### Manual backup
+
+
 
 
 #### Admin users

--- a/README.md
+++ b/README.md
@@ -340,8 +340,9 @@ Sort can be `time`, `active` or `score`. Supported sort order with prefix -/+, i
 * `GET /api/v1/list?site=site-id&limit=5&skip=2` - list commented posts, returns array or `PostInfo`, limit=0 will return all posts
   ```go
   type PostInfo struct {
-      URL   string `json:"url"`
-      Count int    `json:"count"`
+      URL   string      `json:"url"`
+      Count int         `json:"count"`
+      ReadOnly bool     `json:"read_only,omitempty"`
       FirstTS time.Time `json:"first_time,omitempty"`
       LastTS  time.Time `json:"last_time,omitempty"`
   }
@@ -383,6 +384,7 @@ Sort can be `time`, `active` or `score`. Supported sort order with prefix -/+, i
 * `POST /api/v1/admin/import?site=side-id` - import comments from the backup.
 * `PUT /api/v1/admin/pin/{id}?site=site-id&url=post-url&pin=1` - pin or unpin comment.
 * `DELETE /api/v1/admin/user/{userid}?site=site-id&block=1` - delete all user's comments.
+* `PUT /api/v1/admin/readonly?site=site-id&url=post-url&ro=1` - set read-only status
 
 _all admin calls require auth and admin privilege_
 

--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ In plain format result will be sorted list of `Comment`. In tree format this is 
 ```go
 type Tree struct {
     Nodes []Node `json:"comments"`
+    Info  store.PostInfo `json:"info,omitempty"`
 }
 
 type Node struct {
@@ -320,6 +321,8 @@ Sort can be `time`, `active` or `score`. Supported sort order with prefix -/+, i
   type PostInfo struct {
       URL   string `json:"url"`
       Count int    `json:"count"`
+      FirstTS time.Time `json:"first_time,omitempty"`
+      LastTS  time.Time `json:"last_time,omitempty"`
   }
   ```
 * `GET /api/v1/user` - get user info, _auth required_
@@ -336,6 +339,7 @@ Sort can be `time`, `active` or `score`. Supported sort order with prefix -/+, i
       CriticalScore int      `json:"critical_score"`
   }
   ``` 
+* `GET /api/v1/info?site=site-idd&url=post-ur` - returns `PostInfo` for site and url
   
 ### RSS feeds
   

--- a/app/main.go
+++ b/app/main.go
@@ -46,15 +46,15 @@ type Opts struct {
 	SecretKey      string `long:"secret" env:"SECRET" required:"true" description:"secret key"`
 	LowScore       int    `long:"low-score" env:"LOW_SCORE" default:"-5" description:"low score threshold"`
 	CriticalScore  int    `long:"critical-score" env:"CRITICAL_SCORE" default:"-10" description:"critical score threshold"`
-
-	GoogleCID    string `long:"google-cid" env:"REMARK_GOOGLE_CID" description:"Google OAuth client ID"`
-	GoogleCSEC   string `long:"google-csec" env:"REMARK_GOOGLE_CSEC" description:"Google OAuth client secret"`
-	GithubCID    string `long:"github-cid" env:"REMARK_GITHUB_CID" description:"Github OAuth client ID"`
-	GithubCSEC   string `long:"github-csec" env:"REMARK_GITHUB_CSEC" description:"Github OAuth client secret"`
-	FacebookCID  string `long:"facebook-cid" env:"REMARK_FACEBOOK_CID" description:"Facebook OAuth client ID"`
-	FacebookCSEC string `long:"facebook-csec" env:"REMARK_FACEBOOK_CSEC" description:"Facebook OAuth client secret"`
-	DisqusCID    string `long:"disqus-cid" env:"REMARK_DISQUS_CID" description:"Disqus OAuth client ID"`
-	DisqusCSEC   string `long:"disqus-csec" env:"REMARK_DISQUS_CSEC" description:"Disqus OAuth client secret"`
+	ReadOnlyAge    int    `long:"read-age" env:"READONLY_AGE" default:"0" description:"read-only age of comments"`
+	GoogleCID      string `long:"google-cid" env:"REMARK_GOOGLE_CID" description:"Google OAuth client ID"`
+	GoogleCSEC     string `long:"google-csec" env:"REMARK_GOOGLE_CSEC" description:"Google OAuth client secret"`
+	GithubCID      string `long:"github-cid" env:"REMARK_GITHUB_CID" description:"Github OAuth client ID"`
+	GithubCSEC     string `long:"github-csec" env:"REMARK_GITHUB_CSEC" description:"Github OAuth client secret"`
+	FacebookCID    string `long:"facebook-cid" env:"REMARK_FACEBOOK_CID" description:"Facebook OAuth client ID"`
+	FacebookCSEC   string `long:"facebook-csec" env:"REMARK_FACEBOOK_CSEC" description:"Facebook OAuth client secret"`
+	DisqusCID      string `long:"disqus-cid" env:"REMARK_DISQUS_CID" description:"Disqus OAuth client ID"`
+	DisqusCSEC     string `long:"disqus-csec" env:"REMARK_DISQUS_CSEC" description:"Disqus OAuth client secret"`
 
 	Port    int    `long:"port" env:"REMARK_PORT" default:"8080" description:"port"`
 	WebRoot string `long:"web-root" env:"REMARK_WEB_ROOT" default:"./web" description:"web root directory"`
@@ -142,6 +142,7 @@ func New(opts Opts) (*Application, error) {
 		WebRoot:     opts.WebRoot,
 		ImageProxy:  &proxy.Image{Enabled: opts.ImageProxy, RoutePath: "/api/v1/img", RemarkURL: opts.RemarkURL},
 		AvatarProxy: avatarProxy,
+		ReadOnlyAge: opts.ReadOnlyAge,
 		Authenticator: auth.Authenticator{
 			JWTService: jwtService,
 			Admins:     opts.Admins,

--- a/app/rest/api/import.go
+++ b/app/rest/api/import.go
@@ -64,7 +64,7 @@ func (s *Import) Shutdown() {
 func (s *Import) routes() chi.Router {
 	router := chi.NewRouter()
 	router.Use(middleware.RealIP, Recoverer)
-	router.Use(middleware.Throttle(1000), middleware.Timeout(60*time.Second))
+	router.Use(middleware.Throttle(1000), middleware.Timeout(15*time.Minute))
 	router.Use(tollbooth_chi.LimitHandler(tollbooth.NewLimiter(10, nil)))
 	router.Use(AppInfo("remark42-importer", s.Version), Ping, Logger(LogAll))
 	router.Post("/api/v1/admin/import", s.importCtrl)

--- a/app/rest/api/migrator.go
+++ b/app/rest/api/migrator.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"compress/gzip"
 	"context"
 	"fmt"
 	"log"
@@ -20,12 +21,13 @@ import (
 	"github.com/umputun/remark/app/rest/cache"
 )
 
-// Import rest runs on unexposed port and available for local requests only
-type Import struct {
+// Migrator rest runs on unexposed port and available for local requests only
+type Migrator struct {
 	Version        string
 	Cache          cache.LoadingCache
 	NativeImporter migrator.Importer
 	DisqusImporter migrator.Importer
+	NativeExported migrator.Exporter
 	SecretKey      string
 
 	httpServer *http.Server
@@ -34,58 +36,59 @@ type Import struct {
 
 // Run the listener and request's router, activate rest server
 // this server doesn't have any authentication and SHOULDN'T BE EXPOSED in any way
-func (s *Import) Run(port int) {
+func (m *Migrator) Run(port int) {
 	log.Printf("[INFO] activate import server on port %d", port)
-	router := s.routes()
+	router := m.routes()
 
-	s.lock.Lock()
-	s.httpServer = &http.Server{Addr: fmt.Sprintf("127.0.0.1:%d", port), Handler: router}
-	s.lock.Unlock()
+	m.lock.Lock()
+	m.httpServer = &http.Server{Addr: fmt.Sprintf("127.0.0.1:%d", port), Handler: router}
+	m.lock.Unlock()
 
-	err := s.httpServer.ListenAndServe()
+	err := m.httpServer.ListenAndServe()
 	log.Printf("[WARN] http server terminated, %s", err)
 }
 
 // Shutdown import http server
-func (s *Import) Shutdown() {
+func (m *Migrator) Shutdown() {
 	log.Print("[WARN] shutdown import server")
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
-	s.lock.Lock()
-	if err := s.httpServer.Shutdown(ctx); err != nil {
+	m.lock.Lock()
+	if err := m.httpServer.Shutdown(ctx); err != nil {
 		log.Printf("[DEBUG] importer shutdown error, %s", err)
 	}
-	s.lock.Unlock()
+	m.lock.Unlock()
 
 	log.Print("[DEBUG] shutdown import server completed")
 }
 
-func (s *Import) routes() chi.Router {
+func (m *Migrator) routes() chi.Router {
 	router := chi.NewRouter()
 	router.Use(middleware.RealIP, Recoverer)
 	router.Use(middleware.Throttle(1000), middleware.Timeout(15*time.Minute))
 	router.Use(tollbooth_chi.LimitHandler(tollbooth.NewLimiter(10, nil)))
-	router.Use(AppInfo("remark42-importer", s.Version), Ping, Logger(LogAll))
-	router.Post("/api/v1/admin/import", s.importCtrl)
+	router.Use(AppInfo("remark42-importer", m.Version), Ping, Logger(LogAll))
+	router.Post("/api/v1/admin/import", m.importCtrl)
+	router.Get("/api/v1/admin/export", m.exportCtrl)
 	return router
 }
 
 // POST /import?secret=key&site=site-id&provider=disqus|remark
 // imports comments from post body.
-func (s *Import) importCtrl(w http.ResponseWriter, r *http.Request) {
+func (m *Migrator) importCtrl(w http.ResponseWriter, r *http.Request) {
 
 	secret := r.URL.Query().Get("secret")
-	if strings.TrimSpace(secret) == "" || secret != s.SecretKey {
+	if strings.TrimSpace(secret) == "" || secret != m.SecretKey {
 		render.Status(r, http.StatusForbidden)
 		render.JSON(w, r, JSON{"status": "error", "details": "secret key"})
 		return
 	}
 
 	siteID := r.URL.Query().Get("site")
-	importer := s.NativeImporter
+	importer := m.NativeImporter
 	if r.URL.Query().Get("provider") == "disqus" {
-		importer = s.DisqusImporter
+		importer = m.DisqusImporter
 	}
 
 	size, err := importer.Import(r.Body, siteID)
@@ -93,8 +96,38 @@ func (s *Import) importCtrl(w http.ResponseWriter, r *http.Request) {
 		rest.SendErrorJSON(w, r, http.StatusBadRequest, err, "import failed")
 		return
 	}
-	s.Cache.Flush(siteID)
+	m.Cache.Flush(siteID)
 
 	render.Status(r, http.StatusCreated)
 	render.JSON(w, r, JSON{"status": "ok", "size": size})
+}
+
+// GET /export?site=site-id&secret=12345
+// exports all comments for siteID as json stream or gz file
+func (m *Migrator) exportCtrl(w http.ResponseWriter, r *http.Request) {
+
+	secret := r.URL.Query().Get("secret")
+	if strings.TrimSpace(secret) == "" || secret != m.SecretKey {
+		render.Status(r, http.StatusForbidden)
+		render.JSON(w, r, JSON{"status": "error", "details": "secret key"})
+		return
+	}
+
+	siteID := r.URL.Query().Get("site")
+
+	exportFile := fmt.Sprintf("%s-%s.json.gz", siteID, time.Now().Format("20060102"))
+	w.Header().Set("Content-Type", "application/gzip")
+	w.Header().Set("Content-Disposition", "attachment;filename="+exportFile)
+	w.WriteHeader(http.StatusOK)
+	gzWriter := gzip.NewWriter(w)
+	defer func() {
+		if e := gzWriter.Close(); e != nil {
+			log.Printf("[WARN] can't close gzip writer, %s", e)
+		}
+	}()
+
+	if _, err := m.NativeExported.Export(gzWriter, siteID); err != nil {
+		rest.SendErrorJSON(w, r, http.StatusInternalServerError, err, "export failed")
+		return
+	}
 }

--- a/app/rest/api/migrator_test.go
+++ b/app/rest/api/migrator_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"compress/gzip"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -18,7 +19,7 @@ import (
 	"github.com/umputun/remark/app/store/service"
 )
 
-func TestImport(t *testing.T) {
+func TestMigrator_Import(t *testing.T) {
 	srv, ts := prepImportSrv(t)
 	assert.NotNil(t, srv)
 	defer cleanupImportSrv(srv, ts)
@@ -38,7 +39,7 @@ func TestImport(t *testing.T) {
 	assert.Equal(t, `{"size":2,"status":"ok"}`+"\n", string(b))
 }
 
-func TestImportRejected(t *testing.T) {
+func TestMigrator_ImportRejected(t *testing.T) {
 	srv, ts := prepImportSrv(t)
 	assert.NotNil(t, srv)
 	defer cleanupImportSrv(srv, ts)
@@ -54,8 +55,45 @@ func TestImportRejected(t *testing.T) {
 	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
 }
 
-func TestImportShutdown(t *testing.T) {
-	srv := Import{}
+func TestMigrator_Export(t *testing.T) {
+	srv, ts := prepImportSrv(t)
+	assert.NotNil(t, srv)
+	defer cleanupImportSrv(srv, ts)
+
+	r := strings.NewReader(`{"id":"2aa0478c-df1b-46b1-b561-03d507cf482c","pid":"","text":"<p>test test #1</p>","user":{"name":"developer one","id":"dev","picture":"/api/v1/avatar/remark.image","profile":"https://remark42.com","admin":true,"ip":"ae12fe3b5f129b5cc4cdd2b136b7b7947c4d2741"},"locator":{"site":"radio-t","url":"https://radio-t.com/blah1"},"score":0,"votes":{},"time":"2018-04-30T01:37:00.849053725-05:00"}
+	{"id":"83fd97fd-ff64-48d1-9fb7-ca7769c77037","pid":"p1","text":"<p>test test #2</p>","user":{"name":"developer one","id":"dev","picture":"/api/v1/avatar/remark.image","profile":"https://remark42.com","admin":true,"ip":"ae12fe3b5f129b5cc4cdd2b136b7b7947c4d2741"},"locator":{"site":"radio-t","url":"https://radio-t.com/blah2"},"score":0,"votes":{},"time":"2018-04-30T01:37:00.861387771-05:00"}`)
+
+	client := &http.Client{Timeout: 1 * time.Second}
+	req, err := http.NewRequest("POST", ts.URL+"/api/v1/admin/import?site=radio-t&provider=native&secret=123456", r)
+	require.Nil(t, err)
+	resp, err := client.Do(req)
+	require.Nil(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	req, err = http.NewRequest("GET", ts.URL+"/api/v1/admin/export?site=radio-t&secret=123456", nil)
+	require.Nil(t, err)
+	resp, err = client.Do(req)
+	require.Nil(t, err)
+	require.Equal(t, 200, resp.StatusCode)
+	require.Equal(t, "application/gzip", resp.Header.Get("Content-Type"))
+
+	ungzReader, err := gzip.NewReader(resp.Body)
+	assert.NoError(t, err)
+	ungzBody, err := ioutil.ReadAll(ungzReader)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, strings.Count(string(ungzBody), "\n"))
+	assert.Equal(t, 2, strings.Count(string(ungzBody), "\"text\""))
+	t.Logf("%s", string(ungzBody))
+
+	req, err = http.NewRequest("GET", ts.URL+"/api/v1/admin/export?site=radio-t&secret=bad", nil)
+	require.Nil(t, err)
+	resp, err = client.Do(req)
+	require.Nil(t, err)
+	require.Equal(t, 403, resp.StatusCode)
+}
+
+func TestMigrator_Shutdown(t *testing.T) {
+	srv := Migrator{}
 	go func() {
 		time.Sleep(100 * time.Millisecond)
 		srv.Shutdown()
@@ -65,13 +103,14 @@ func TestImportShutdown(t *testing.T) {
 	assert.True(t, time.Since(st).Seconds() < 1, "should take about 100ms")
 }
 
-func prepImportSrv(t *testing.T) (svc *Import, ts *httptest.Server) {
+func prepImportSrv(t *testing.T) (svc *Migrator, ts *httptest.Server) {
 	b, err := engine.NewBoltDB(bolt.Options{}, engine.BoltSite{FileName: testDb, SiteID: "radio-t"})
 	require.Nil(t, err)
 	dataStore := &service.DataStore{Interface: b}
-	svc = &Import{
+	svc = &Migrator{
 		DisqusImporter: &migrator.Disqus{DataStore: dataStore},
 		NativeImporter: &migrator.Remark{DataStore: dataStore},
+		NativeExported: &migrator.Remark{DataStore: dataStore},
 		Cache:          &mockCache{},
 		SecretKey:      "123456",
 	}
@@ -81,7 +120,7 @@ func prepImportSrv(t *testing.T) (svc *Import, ts *httptest.Server) {
 	return svc, ts
 }
 
-func cleanupImportSrv(srv *Import, ts *httptest.Server) {
+func cleanupImportSrv(srv *Migrator, ts *httptest.Server) {
 	ts.Close()
 	os.Remove(testDb)
 }

--- a/app/rest/api/rest.go
+++ b/app/rest/api/rest.go
@@ -203,9 +203,11 @@ func (s *Rest) createCommentCtrl(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if info, e := s.DataService.Info(comment.Locator, s.ReadOnlyAge); e == nil && info.ReadOnly {
-		rest.SendErrorJSON(w, r, http.StatusForbidden, errors.New("rejected"), "old post, read-only")
-		return
+	if s.ReadOnlyAge > 0 {
+		if info, e := s.DataService.Info(comment.Locator, s.ReadOnlyAge); e == nil && info.ReadOnly {
+			rest.SendErrorJSON(w, r, http.StatusForbidden, errors.New("rejected"), "old post, read-only")
+			return
+		}
 	}
 
 	id, err := s.DataService.Create(comment)

--- a/app/rest/api/rest.go
+++ b/app/rest/api/rest.go
@@ -203,7 +203,7 @@ func (s *Rest) createCommentCtrl(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if info, err := s.DataService.Info(comment.Locator, s.ReadOnlyAge); err == nil && info.ReadOnly {
+	if info, e := s.DataService.Info(comment.Locator, s.ReadOnlyAge); e == nil && info.ReadOnly {
 		rest.SendErrorJSON(w, r, http.StatusForbidden, errors.New("rejected"), "old post, read-only")
 		return
 	}

--- a/app/rest/api/rest_test.go
+++ b/app/rest/api/rest_test.go
@@ -198,6 +198,8 @@ func TestServer_Find(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(tree.Nodes))
 	assert.Equal(t, 1, len(tree.Nodes[0].Replies))
+	assert.Equal(t, 2, tree.Info.Count)
+	assert.Equal(t, "https://radio-t.com/blah1", tree.Info.URL)
 }
 
 func TestServer_Update(t *testing.T) {

--- a/app/rest/api/rest_test.go
+++ b/app/rest/api/rest_test.go
@@ -81,6 +81,7 @@ func TestServer_CreateOldPost(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusCreated, resp.StatusCode)
 
+	assert.Nil(t, srv.DataService.DeleteAll("radio-t"))
 	// make too old comment
 	old = store.Comment{Text: "test test old", ParentID: "", Timestamp: time.Now().AddDate(0, 0, -15),
 		Locator: store.Locator{SiteID: "radio-t", URL: "https://radio-t.com/blah1"}, User: store.User{ID: "u1"}}

--- a/app/rest/api/rest_test.go
+++ b/app/rest/api/rest_test.go
@@ -29,7 +29,7 @@ import (
 var testDb = "/tmp/test-remark.db"
 var testHTML = "/tmp/test-remark.html"
 
-func TestServer_Ping(t *testing.T) {
+func TestRest_Ping(t *testing.T) {
 	srv, ts := prep(t)
 	require.NotNil(t, srv)
 	defer cleanup(ts)
@@ -39,7 +39,7 @@ func TestServer_Ping(t *testing.T) {
 	assert.Equal(t, 200, code)
 }
 
-func TestServer_Create(t *testing.T) {
+func TestRest_Create(t *testing.T) {
 	srv, ts := prep(t)
 	require.NotNil(t, srv)
 	defer cleanup(ts)
@@ -60,7 +60,7 @@ func TestServer_Create(t *testing.T) {
 	assert.True(t, len(c["id"].(string)) > 8)
 }
 
-func TestServer_CreateOldPost(t *testing.T) {
+func TestRest_CreateOldPost(t *testing.T) {
 	srv, ts := prep(t)
 	require.NotNil(t, srv)
 	defer cleanup(ts)
@@ -94,7 +94,7 @@ func TestServer_CreateOldPost(t *testing.T) {
 	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
 }
 
-func TestServer_CreateTooBig(t *testing.T) {
+func TestRest_CreateTooBig(t *testing.T) {
 	srv, ts := prep(t)
 	require.NotNil(t, srv)
 	defer cleanup(ts)
@@ -114,7 +114,7 @@ func TestServer_CreateTooBig(t *testing.T) {
 	assert.Equal(t, "invalid comment", c["details"])
 }
 
-func TestServer_Preview(t *testing.T) {
+func TestRest_Preview(t *testing.T) {
 	srv, ts := prep(t)
 	require.NotNil(t, srv)
 	defer cleanup(ts)
@@ -127,7 +127,7 @@ func TestServer_Preview(t *testing.T) {
 	assert.Equal(t, "<p>test 123</p>\n", string(b))
 }
 
-func TestServer_PreviewWithMD(t *testing.T) {
+func TestRest_PreviewWithMD(t *testing.T) {
 	srv, ts := prep(t)
 	require.NotNil(t, srv)
 	defer cleanup(ts)
@@ -136,7 +136,7 @@ func TestServer_PreviewWithMD(t *testing.T) {
 # h1
 
 BKT
-func TestServer_Preview(t *testing.T) {
+func TestRest_Preview(t *testing.T) {
 srv, ts := prep(t)
   require.NotNil(t, srv)
 }
@@ -152,10 +152,10 @@ BKT
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	b, err := ioutil.ReadAll(resp.Body)
 	assert.Nil(t, err)
-	assert.Equal(t, "<h1>h1</h1>\n\n<pre><code>func TestServer_Preview(t *testing.T) {\nsrv, ts := prep(t)\n  require.NotNil(t, srv)\n}\n</code></pre>\n", string(b))
+	assert.Equal(t, "<h1>h1</h1>\n\n<pre><code>func TestRest_Preview(t *testing.T) {\nsrv, ts := prep(t)\n  require.NotNil(t, srv)\n}\n</code></pre>\n", string(b))
 }
 
-func TestServer_CreateAndGet(t *testing.T) {
+func TestRest_CreateAndGet(t *testing.T) {
 	srv, ts := prep(t)
 	assert.NotNil(t, srv)
 	defer cleanup(ts)
@@ -187,7 +187,7 @@ func TestServer_CreateAndGet(t *testing.T) {
 	t.Logf("%+v", comment)
 }
 
-func TestServer_Find(t *testing.T) {
+func TestRest_Find(t *testing.T) {
 	srv, ts := prep(t)
 	assert.NotNil(t, srv)
 	defer cleanup(ts)
@@ -237,7 +237,7 @@ func TestServer_Find(t *testing.T) {
 	assert.False(t, tree.Info.ReadOnly, "post is fresh")
 }
 
-func TestServer_FindAge(t *testing.T) {
+func TestRest_FindAge(t *testing.T) {
 	srv, ts := prep(t)
 	assert.NotNil(t, srv)
 	defer cleanup(ts)
@@ -269,7 +269,7 @@ func TestServer_FindAge(t *testing.T) {
 	assert.True(t, tree.Info.ReadOnly, "post is old")
 }
 
-func TestServer_Update(t *testing.T) {
+func TestRest_Update(t *testing.T) {
 	srv, ts := prep(t)
 	assert.NotNil(t, srv)
 	defer cleanup(ts)
@@ -308,7 +308,7 @@ func TestServer_Update(t *testing.T) {
 	assert.Equal(t, c2, c3, "same as response from update")
 }
 
-func TestServer_Last(t *testing.T) {
+func TestRest_Last(t *testing.T) {
 	srv, ts := prep(t)
 	assert.NotNil(t, srv)
 	defer cleanup(ts)
@@ -353,7 +353,7 @@ func TestServer_Last(t *testing.T) {
 	assert.Equal(t, 2, len(comments), "should have 2 comments")
 }
 
-func TestServer_FindUserComments(t *testing.T) {
+func TestRest_FindUserComments(t *testing.T) {
 	srv, ts := prep(t)
 	assert.NotNil(t, srv)
 	defer cleanup(ts)
@@ -385,7 +385,7 @@ func TestServer_FindUserComments(t *testing.T) {
 	assert.Equal(t, 3, resp.Count, "should have 3 count")
 }
 
-func TestServer_UserInfo(t *testing.T) {
+func TestRest_UserInfo(t *testing.T) {
 	srv, ts := prep(t)
 	assert.NotNil(t, srv)
 	defer cleanup(ts)
@@ -399,7 +399,7 @@ func TestServer_UserInfo(t *testing.T) {
 		Picture: "/api/v1/avatar/remark.image", Admin: true, Blocked: false, IP: ""}, user)
 }
 
-func TestServer_Vote(t *testing.T) {
+func TestRest_Vote(t *testing.T) {
 	srv, ts := prep(t)
 	assert.NotNil(t, srv)
 	defer cleanup(ts)
@@ -443,7 +443,7 @@ func TestServer_Vote(t *testing.T) {
 	assert.Equal(t, map[string]bool{}, cr.Votes)
 }
 
-func TestServer_Count(t *testing.T) {
+func TestRest_Count(t *testing.T) {
 	srv, ts := prep(t)
 	assert.NotNil(t, srv)
 	defer cleanup(ts)
@@ -473,7 +473,7 @@ func TestServer_Count(t *testing.T) {
 	assert.Equal(t, 2.0, j["count"])
 }
 
-func TestServer_Counts(t *testing.T) {
+func TestRest_Counts(t *testing.T) {
 	srv, ts := prep(t)
 	assert.NotNil(t, srv)
 	defer cleanup(ts)
@@ -503,7 +503,7 @@ func TestServer_Counts(t *testing.T) {
 		{URL: "https://radio-t.com/blah2", Count: 2}}), j)
 }
 
-func TestServer_List(t *testing.T) {
+func TestRest_List(t *testing.T) {
 	srv, ts := prep(t)
 	assert.NotNil(t, srv)
 	defer cleanup(ts)
@@ -530,7 +530,7 @@ func TestServer_List(t *testing.T) {
 	assert.Equal(t, 3, pi[1].Count)
 }
 
-func TestServer_Config(t *testing.T) {
+func TestRest_Config(t *testing.T) {
 	srv, ts := prep(t)
 	assert.NotNil(t, srv)
 	defer cleanup(ts)
@@ -549,7 +549,7 @@ func TestServer_Config(t *testing.T) {
 	t.Logf("%+v", j)
 }
 
-func TestServer_Info(t *testing.T) {
+func TestRest_Info(t *testing.T) {
 	srv, ts := prep(t)
 	assert.NotNil(t, srv)
 	defer cleanup(ts)
@@ -585,7 +585,7 @@ func TestServer_Info(t *testing.T) {
 	assert.Equal(t, 400, code)
 }
 
-func TestServer_FileServer(t *testing.T) {
+func TestRest_FileServer(t *testing.T) {
 	srv, ts := prep(t)
 	assert.NotNil(t, srv)
 	defer cleanup(ts)
@@ -595,7 +595,7 @@ func TestServer_FileServer(t *testing.T) {
 	assert.Equal(t, "some html", body)
 }
 
-func TestServer_Shutdown(t *testing.T) {
+func TestRest_Shutdown(t *testing.T) {
 	srv := Rest{Authenticator: auth.Authenticator{},
 		AvatarProxy: &proxy.Avatar{StorePath: "/tmp", RoutePath: "/api/v1/avatar"}, ImageProxy: &proxy.Image{}}
 	go func() {

--- a/app/rest/api/rest_test.go
+++ b/app/rest/api/rest_test.go
@@ -524,7 +524,10 @@ func TestServer_List(t *testing.T) {
 	pi := []store.PostInfo{}
 	err := json.Unmarshal([]byte(body), &pi)
 	assert.Nil(t, err)
-	assert.Equal(t, []store.PostInfo{{URL: "https://radio-t.com/blah2", Count: 2}, {URL: "https://radio-t.com/blah1", Count: 3}}, pi)
+	assert.Equal(t, "https://radio-t.com/blah2", pi[0].URL)
+	assert.Equal(t, 2, pi[0].Count)
+	assert.Equal(t, "https://radio-t.com/blah1", pi[1].URL)
+	assert.Equal(t, 3, pi[1].Count)
 }
 
 func TestServer_Config(t *testing.T) {

--- a/app/rest/api/rest_test.go
+++ b/app/rest/api/rest_test.go
@@ -268,6 +268,20 @@ func TestServer_Last(t *testing.T) {
 	err = json.Unmarshal([]byte(res), &comments)
 	assert.Nil(t, err)
 	assert.Equal(t, 3, len(comments), "should have 3 comments")
+
+	res, code = get(t, ts.URL+"/api/v1/last/X?site=radio-t")
+	assert.Equal(t, 200, code)
+	err = json.Unmarshal([]byte(res), &comments)
+	assert.Nil(t, err)
+	assert.Equal(t, 3, len(comments), "should have 3 comments")
+
+	err = srv.DataService.Delete(store.Locator{SiteID: "radio-t", URL: "https://radio-t.com/blah1"}, id1, store.SoftDelete)
+	assert.Nil(t, err)
+	res, code = get(t, ts.URL+"/api/v1/last/5?site=radio-t")
+	assert.Equal(t, 200, code)
+	err = json.Unmarshal([]byte(res), &comments)
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(comments), "should have 2 comments")
 }
 
 func TestServer_FindUserComments(t *testing.T) {
@@ -491,6 +505,11 @@ func TestServer_Info(t *testing.T) {
 	exp := store.PostInfo{URL: "https://radio-t.com/blah1", Count: 3,
 		FirstTS: time.Date(2018, 05, 27, 1, 14, 10, 0, time.Local), LastTS: time.Date(2018, 05, 27, 1, 14, 25, 0, time.Local)}
 	assert.Equal(t, exp, info)
+
+	_, code = get(t, ts.URL+"/api/v1/info?site=radio-t&url=https://radio-t.com/blah-no")
+	assert.Equal(t, 400, code)
+	_, code = get(t, ts.URL+"/api/v1/info?site=radio-t-no&url=https://radio-t.com/blah-no")
+	assert.Equal(t, 400, code)
 }
 
 func TestServer_FileServer(t *testing.T) {

--- a/app/rest/api/rss_test.go
+++ b/app/rest/api/rss_test.go
@@ -16,7 +16,7 @@ func TestServer_RssPost(t *testing.T) {
 	assert.NotNil(t, srv)
 	defer cleanup(ts)
 
-	waitOnMinChange()
+	waitOnSecChange()
 
 	c1 := store.Comment{
 		Text:    "test 123",
@@ -57,7 +57,7 @@ func TestServer_RssSite(t *testing.T) {
 	assert.NotNil(t, srv)
 	defer cleanup(ts)
 
-	waitOnMinChange()
+	waitOnSecChange()
 
 	pubDate := time.Now().Format(time.RFC1123Z)
 
@@ -111,7 +111,7 @@ func TestServer_RssWithReply(t *testing.T) {
 	assert.NotNil(t, srv)
 	defer cleanup(ts)
 
-	waitOnMinChange()
+	waitOnSecChange()
 
 	pubDate := time.Now().Format(time.RFC1123Z)
 
@@ -158,9 +158,9 @@ func TestServer_RssWithReply(t *testing.T) {
 	assert.Equal(t, expected, res)
 }
 
-func waitOnMinChange() {
+func waitOnSecChange() {
 	for {
-		if time.Now().Nanosecond() > 500000000 {
+		if time.Now().Nanosecond() < 100000000 {
 			break
 		}
 		time.Sleep(10 * time.Nanosecond)

--- a/app/rest/proxy/image_test.go
+++ b/app/rest/proxy/image_test.go
@@ -94,6 +94,14 @@ func TestPicture_Convert(t *testing.T) {
 
 	r = img.Convert(`<img src="https://radio-t.com/img3.png"/> xyz <img src="http://images.pexels.com/67636/img4.jpeg">`)
 	assert.Equal(t, `<img src="https://radio-t.com/img3.png"/> xyz <img src="/img?src=aHR0cDovL2ltYWdlcy5wZXhlbHMuY29tLzY3NjM2L2ltZzQuanBlZw==">`, r)
+
+	img = Image{Enabled: true, RoutePath: "/img", RemarkURL: "http://example.com"}
+	r = img.Convert(`<img src="http://radio-t.com/img3.png"/> xyz`)
+	assert.Equal(t, `<img src="http://radio-t.com/img3.png"/> xyz`, r, "http:// remark url, no proxy")
+
+	img = Image{Enabled: false, RoutePath: "/img"}
+	r = img.Convert(`<img src="http://radio-t.com/img3.png"/> xyz`)
+	assert.Equal(t, `<img src="http://radio-t.com/img3.png"/> xyz`, r, "disabled, no proxy")
 }
 
 func imgHTTPServer(t *testing.T) *httptest.Server {

--- a/app/rest/tree.go
+++ b/app/rest/tree.go
@@ -30,7 +30,7 @@ type recurData struct {
 }
 
 // MakeTree gets unsorted list of comments and produces Tree
-func MakeTree(comments []store.Comment, sortType string) *Tree {
+func MakeTree(comments []store.Comment, sortType string, readOnlyAge int) *Tree {
 	if len(comments) == 0 {
 		return &Tree{}
 	}
@@ -63,6 +63,9 @@ func MakeTree(comments []store.Comment, sortType string) *Tree {
 		if commentsTree.tsModified.After(res.Info.LastTS) {
 			res.Info.LastTS = commentsTree.tsModified
 		}
+
+		res.Info.ReadOnly = readOnlyAge > 0 && !res.Info.FirstTS.IsZero() &&
+			res.Info.FirstTS.AddDate(0, 0, readOnlyAge).Before(time.Now())
 
 		res.Nodes = append(res.Nodes, commentsTree)
 	}

--- a/app/rest/tree.go
+++ b/app/rest/tree.go
@@ -10,25 +10,39 @@ import (
 
 // Tree is formatter making tree from list of comments
 type Tree struct {
-	Nodes []*Node `json:"comments"`
+	Nodes []*Node        `json:"comments"`
+	Info  store.PostInfo `json:"info,omitempty"`
 }
 
 // Node is a comment with optional replies
 type Node struct {
-	Comment store.Comment `json:"comment"`
-	Replies []*Node       `json:"replies,omitempty"`
-	ts      time.Time
+	Comment    store.Comment `json:"comment"`
+	Replies    []*Node       `json:"replies,omitempty"`
+	tsModified time.Time
+	tsCreated  time.Time
 }
 
 // recurData wraps all fileds used in recursive processing as intermediate results
 type recurData struct {
-	ts      time.Time
-	visible bool
+	tsModified time.Time
+	tsCreated  time.Time
+	visible    bool
 }
 
 // MakeTree gets unsorted list of comments and produces Tree
 func MakeTree(comments []store.Comment, sortType string) *Tree {
-	res := Tree{}
+	if len(comments) == 0 {
+		return &Tree{}
+	}
+
+	res := Tree{
+		Info: store.PostInfo{
+			URL:     comments[0].Locator.URL,
+			Count:   len(comments), // TODO: includes deleted?
+			FirstTS: comments[0].Timestamp,
+			LastTS:  comments[0].Timestamp,
+		},
+	}
 
 	topComments := res.filter(comments, "")
 	res.Nodes = []*Node{}
@@ -36,12 +50,20 @@ func MakeTree(comments []store.Comment, sortType string) *Tree {
 		node := Node{Comment: rootComment}
 
 		rd := recurData{}
-		commentsTree, t := res.proc(comments, &node, &rd, rootComment.ID)
+		commentsTree, tsModified, tsCreated := res.proc(comments, &node, &rd, rootComment.ID)
 		// skip deleted with no sub-comments ar all sub-comments deleted
 		if rootComment.Deleted && (len(commentsTree.Replies) == 0 || !rd.visible) {
 			continue
 		}
-		commentsTree.ts = t
+
+		commentsTree.tsModified, commentsTree.tsCreated = tsModified, tsCreated
+		if commentsTree.tsCreated.Before(res.Info.FirstTS) {
+			res.Info.FirstTS = commentsTree.tsCreated
+		}
+		if commentsTree.tsModified.After(res.Info.LastTS) {
+			res.Info.LastTS = commentsTree.tsModified
+		}
+
 		res.Nodes = append(res.Nodes, commentsTree)
 	}
 
@@ -50,16 +72,19 @@ func MakeTree(comments []store.Comment, sortType string) *Tree {
 }
 
 // proc makes tree for one top-level comment recursively
-func (t *Tree) proc(comments []store.Comment, node *Node, rd *recurData, parentID string) (*Node, time.Time) {
+func (t *Tree) proc(comments []store.Comment, node *Node, rd *recurData, parentID string) (*Node, time.Time, time.Time) {
 
-	if rd.ts.IsZero() {
-		rd.ts = node.Comment.Timestamp
+	if rd.tsModified.IsZero() || rd.tsCreated.IsZero() {
+		rd.tsModified, rd.tsCreated = node.Comment.Timestamp, node.Comment.Timestamp
 	}
 
 	repComments := t.filter(comments, parentID)
 	for _, rc := range repComments {
-		if rc.Timestamp.After(rd.ts) {
-			rd.ts = rc.Timestamp
+		if rc.Timestamp.After(rd.tsModified) {
+			rd.tsModified = rc.Timestamp
+		}
+		if rc.Timestamp.Before(rd.tsCreated) {
+			rd.tsCreated = rc.Timestamp
 		}
 		if !rc.Deleted {
 			rd.visible = true
@@ -72,7 +97,7 @@ func (t *Tree) proc(comments []store.Comment, node *Node, rd *recurData, parentI
 	sort.Slice(node.Replies, func(i, j int) bool {
 		return node.Replies[i].Comment.Timestamp.Before(node.Replies[j].Comment.Timestamp)
 	})
-	return node, rd.ts
+	return node, rd.tsModified, rd.tsCreated
 }
 
 // filter returns comments for parentID
@@ -87,7 +112,7 @@ func (t *Tree) filter(comments []store.Comment, parentID string) (f []store.Comm
 }
 
 // sort list of nodes, i.e. top-level comments
-// time sort uses ts from latest reply
+// time sort uses tsModified from latest reply
 func (t *Tree) sortNodes(sortType string) {
 
 	sort.Slice(t.Nodes, func(i, j int) bool {
@@ -100,9 +125,9 @@ func (t *Tree) sortNodes(sortType string) {
 
 		case "+active", "-active", "active":
 			if strings.HasPrefix(sortType, "-") {
-				return t.Nodes[i].ts.After(t.Nodes[j].ts)
+				return t.Nodes[i].tsModified.After(t.Nodes[j].tsModified)
 			}
-			return t.Nodes[i].ts.Before(t.Nodes[j].ts)
+			return t.Nodes[i].tsModified.Before(t.Nodes[j].tsModified)
 
 		case "+score", "-score", "score":
 			if strings.HasPrefix(sortType, "-") {

--- a/app/rest/tree_test.go
+++ b/app/rest/tree_test.go
@@ -40,7 +40,7 @@ func TestMakeTree(t *testing.T) {
 		{Locator: loc, ID: "611", ParentID: "61", Deleted: true},
 	}
 
-	res := MakeTree(comments, "time")
+	res := MakeTree(comments, "time", 0)
 
 	buf := &bytes.Buffer{}
 	enc := json.NewEncoder(buf)
@@ -51,8 +51,11 @@ func TestMakeTree(t *testing.T) {
 	assert.Equal(t, expected, actual)
 	assert.Equal(t, store.PostInfo{URL: "url", Count: 17, FirstTS: ts(46, 1), LastTS: ts(47, 22)}, res.Info)
 
-	res = MakeTree([]store.Comment{}, "time")
+	res = MakeTree([]store.Comment{}, "time", 0)
 	assert.Equal(t, &Tree{}, res)
+
+	res = MakeTree(comments, "time", 10)
+	assert.Equal(t, store.PostInfo{URL: "url", Count: 17, FirstTS: ts(46, 1), LastTS: ts(47, 22), ReadOnly: true}, res.Info)
 }
 
 func TestTreeSortNodes(t *testing.T) {
@@ -74,40 +77,39 @@ func TestTreeSortNodes(t *testing.T) {
 		{ID: "5", Deleted: true},
 	}
 
-	res := MakeTree(comments, "+active")
+	res := MakeTree(comments, "+active", 0)
 	assert.Equal(t, "2", res.Nodes[0].Comment.ID)
 	t.Log(res.Nodes[0].Comment.ID, res.Nodes[0].tsModified)
 
-	res = MakeTree(comments, "-active")
+	res = MakeTree(comments, "-active", 0)
 	t.Log(res.Nodes[0].Comment.ID, res.Nodes[0].tsModified)
 	assert.Equal(t, "1", res.Nodes[0].Comment.ID)
 
-	res = MakeTree(comments, "+time")
+	res = MakeTree(comments, "+time", 0)
 	t.Log(res.Nodes[0].Comment.ID, res.Nodes[0].tsModified)
 	assert.Equal(t, "1", res.Nodes[0].Comment.ID)
 
-	res = MakeTree(comments, "-time")
+	res = MakeTree(comments, "-time", 0)
 	assert.Equal(t, "6", res.Nodes[0].Comment.ID)
 
-	res = MakeTree(comments, "score")
+	res = MakeTree(comments, "score", 0)
 	assert.Equal(t, "4", res.Nodes[0].Comment.ID)
 	assert.Equal(t, "3", res.Nodes[1].Comment.ID)
 	assert.Equal(t, "6", res.Nodes[2].Comment.ID)
 	assert.Equal(t, "1", res.Nodes[3].Comment.ID)
 
-	res = MakeTree(comments, "+score")
+	res = MakeTree(comments, "+score", 0)
 	assert.Equal(t, "4", res.Nodes[0].Comment.ID)
 
-	res = MakeTree(comments, "-score")
+	res = MakeTree(comments, "-score", 0)
 	assert.Equal(t, "2", res.Nodes[0].Comment.ID)
 	assert.Equal(t, "1", res.Nodes[1].Comment.ID)
 	assert.Equal(t, "3", res.Nodes[2].Comment.ID)
 	assert.Equal(t, "6", res.Nodes[3].Comment.ID)
 
-	res = MakeTree(comments, "undefined")
+	res = MakeTree(comments, "undefined", 0)
 	t.Log(res.Nodes[0].Comment.ID, res.Nodes[0].tsModified)
 	assert.Equal(t, "1", res.Nodes[0].Comment.ID)
-
 }
 
 func BenchmarkTree(b *testing.B) {
@@ -118,7 +120,7 @@ func BenchmarkTree(b *testing.B) {
 	assert.Nil(b, err)
 
 	for i := 0; i < b.N; i++ {
-		res := MakeTree(comments, "time")
+		res := MakeTree(comments, "time", 0)
 		assert.NotNil(b, res)
 	}
 }

--- a/app/rest/tree_test.go
+++ b/app/rest/tree_test.go
@@ -49,8 +49,10 @@ func TestMakeTree(t *testing.T) {
 	assert.Nil(t, err)
 	expected, actual := cleanFormatting(expJSON, buf.String())
 	assert.Equal(t, expected, actual)
-
 	assert.Equal(t, store.PostInfo{URL: "url", Count: 17, FirstTS: ts(46, 1), LastTS: ts(47, 22)}, res.Info)
+
+	res = MakeTree([]store.Comment{}, "time")
+	assert.Equal(t, &Tree{}, res)
 }
 
 func TestTreeSortNodes(t *testing.T) {
@@ -82,6 +84,8 @@ func TestTreeSortNodes(t *testing.T) {
 
 	res = MakeTree(comments, "+time")
 	t.Log(res.Nodes[0].Comment.ID, res.Nodes[0].tsModified)
+	assert.Equal(t, "1", res.Nodes[0].Comment.ID)
+
 	res = MakeTree(comments, "-time")
 	assert.Equal(t, "6", res.Nodes[0].Comment.ID)
 
@@ -99,6 +103,11 @@ func TestTreeSortNodes(t *testing.T) {
 	assert.Equal(t, "1", res.Nodes[1].Comment.ID)
 	assert.Equal(t, "3", res.Nodes[2].Comment.ID)
 	assert.Equal(t, "6", res.Nodes[3].Comment.ID)
+
+	res = MakeTree(comments, "undefined")
+	t.Log(res.Nodes[0].Comment.ID, res.Nodes[0].tsModified)
+	assert.Equal(t, "1", res.Nodes[0].Comment.ID)
+
 }
 
 func BenchmarkTree(b *testing.B) {

--- a/app/store/comment.go
+++ b/app/store/comment.go
@@ -38,10 +38,11 @@ type Edit struct {
 
 // PostInfo holds summary for given post url
 type PostInfo struct {
-	URL     string    `json:"url"`
-	Count   int       `json:"count"`
-	FirstTS time.Time `json:"first_time,omitempty"`
-	LastTS  time.Time `json:"last_time,omitempty"`
+	URL      string    `json:"url"`
+	Count    int       `json:"count"`
+	ReadOnly bool      `json:"read_only,omitempty"`
+	FirstTS  time.Time `json:"first_time,omitempty"`
+	LastTS   time.Time `json:"last_time,omitempty"`
 }
 
 // BlockedUser holds id and ts for blocked user

--- a/app/store/comment.go
+++ b/app/store/comment.go
@@ -38,8 +38,10 @@ type Edit struct {
 
 // PostInfo holds summary for given post url
 type PostInfo struct {
-	URL   string `json:"url"`
-	Count int    `json:"count"`
+	URL     string    `json:"url"`
+	Count   int       `json:"count"`
+	FirstTS time.Time `json:"first_time,omitempty"`
+	LastTS  time.Time `json:"last_time,omitempty"`
 }
 
 // BlockedUser holds id and ts for blocked user

--- a/app/store/engine/bolt_accessor.go
+++ b/app/store/engine/bolt_accessor.go
@@ -243,12 +243,12 @@ func (b BoltDB) List(siteID string, limit, skip int) (list []store.PostInfo, err
 				continue
 			}
 			postURL := string(k)
-			count, e := b.count(tx, postURL, 0)
-			if e != nil {
-				return e
+			infoBkt := tx.Bucket([]byte(infoBucketName))
+			info := store.PostInfo{}
+			if e := b.load(infoBkt, []byte(postURL), &info); e != nil {
+				return errors.Wrapf(e, "can't load info for %s", postURL)
 			}
-
-			list = append(list, store.PostInfo{URL: postURL, Count: count})
+			list = append(list, info)
 			if limit > 0 && len(list) >= limit {
 				break
 			}

--- a/app/store/engine/bolt_accessor.go
+++ b/app/store/engine/bolt_accessor.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/coreos/bbolt"
 	"github.com/pkg/errors"
@@ -478,27 +477,6 @@ func (b *BoltDB) db(siteID string) (*bolt.DB, error) {
 		return res, nil
 	}
 	return nil, errors.Errorf("site %q not found", siteID)
-}
-
-// timeRange gets time of first and last comment
-func (b *BoltDB) timeRange(bkt *bolt.Bucket) (from, to time.Time, err error) {
-	c := bkt.Cursor()
-	_, first := c.First()
-	_, last := c.Last()
-	if first == nil || last == nil {
-		return time.Time{}, time.Time{}, errors.Errorf("no comments")
-	}
-
-	comment := store.Comment{}
-	if err = json.Unmarshal(first, &comment); err != nil {
-		return time.Time{}, time.Time{}, errors.Wrap(err, "failed to unmarshal")
-	}
-	from = comment.Timestamp
-	if err = json.Unmarshal(last, &comment); err != nil {
-		return time.Time{}, time.Time{}, errors.Wrap(err, "failed to unmarshal")
-	}
-	to = comment.Timestamp
-	return from, to, nil
 }
 
 // makeRef creates reference combining url and comment id

--- a/app/store/engine/bolt_accessor_test.go
+++ b/app/store/engine/bolt_accessor_test.go
@@ -165,18 +165,22 @@ func TestBoltDB_Info(t *testing.T) {
 	_, err := b.Create(comment)
 	assert.Nil(t, err)
 
-	r, err := b.Info(store.Locator{URL: "https://radio-t.com/2", SiteID: "radio-t"})
+	r, err := b.Info(store.Locator{URL: "https://radio-t.com/2", SiteID: "radio-t"}, 0)
 	require.Nil(t, err)
 	assert.Equal(t, store.PostInfo{URL: "https://radio-t.com/2", Count: 1, FirstTS: ts(24), LastTS: ts(24)}, r)
 
-	r, err = b.Info(store.Locator{URL: "https://radio-t.com", SiteID: "radio-t"})
+	r, err = b.Info(store.Locator{URL: "https://radio-t.com/2", SiteID: "radio-t"}, 10)
+	require.Nil(t, err)
+	assert.Equal(t, store.PostInfo{URL: "https://radio-t.com/2", Count: 1, FirstTS: ts(24), LastTS: ts(24), ReadOnly: true}, r)
+
+	r, err = b.Info(store.Locator{URL: "https://radio-t.com", SiteID: "radio-t"}, 0)
 	require.Nil(t, err)
 	assert.Equal(t, store.PostInfo{URL: "https://radio-t.com", Count: 2, FirstTS: ts(22), LastTS: ts(23)}, r)
 
-	_, err = b.Info(store.Locator{URL: "https://radio-t.com/error", SiteID: "radio-t"})
+	_, err = b.Info(store.Locator{URL: "https://radio-t.com/error", SiteID: "radio-t"}, 0)
 	require.NotNil(t, err)
 
-	_, err = b.Info(store.Locator{URL: "https://radio-t.com", SiteID: "radio-t-error"})
+	_, err = b.Info(store.Locator{URL: "https://radio-t.com", SiteID: "radio-t-error"}, 0)
 	require.NotNil(t, err)
 }
 

--- a/app/store/engine/bolt_accessor_test.go
+++ b/app/store/engine/bolt_accessor_test.go
@@ -225,8 +225,8 @@ func TestBoltDB_Ref(t *testing.T) {
 }
 
 func TestBoltDB_New(t *testing.T) {
-	_, err := NewBoltDB(bolt.Options{}, BoltSite{FileName: "/dev/nul", SiteID: "radio-t"})
-	assert.EqualError(t, err, "failed to make boltdb for /dev/nul: open /dev/nul: operation not permitted")
+	_, err := NewBoltDB(bolt.Options{}, BoltSite{FileName: "/tmp/no-such-place/tmp.db", SiteID: "radio-t"})
+	assert.EqualError(t, err, "failed to make boltdb for /tmp/no-such-place/tmp.db: open /tmp/no-such-place/tmp.db: no such file or directory")
 }
 
 // makes new boltdb, put two records

--- a/app/store/engine/bolt_accessor_test.go
+++ b/app/store/engine/bolt_accessor_test.go
@@ -155,7 +155,7 @@ func TestBoltDB_Info(t *testing.T) {
 	comment := store.Comment{
 		ID:        "12345",
 		Text:      `some text, <a href="http://radio-t.com">link</a>`,
-		Timestamp: time.Date(2017, 12, 20, 15, 18, 22, 0, time.Local),
+		Timestamp: time.Date(2017, 12, 20, 15, 18, 24, 0, time.Local),
 		Locator:   store.Locator{URL: "https://radio-t.com/2", SiteID: "radio-t"},
 		User:      store.User{ID: "user1", Name: "user name"},
 	}
@@ -164,7 +164,7 @@ func TestBoltDB_Info(t *testing.T) {
 
 	r, err := b.Info(store.Locator{URL: "https://radio-t.com/2", SiteID: "radio-t"})
 	require.Nil(t, err)
-	assert.Equal(t, store.PostInfo{URL: "https://radio-t.com/2", Count: 1, FirstTS: ts(22), LastTS: ts(22)}, r)
+	assert.Equal(t, store.PostInfo{URL: "https://radio-t.com/2", Count: 1, FirstTS: ts(24), LastTS: ts(24)}, r)
 
 	r, err = b.Info(store.Locator{URL: "https://radio-t.com", SiteID: "radio-t"})
 	require.Nil(t, err)

--- a/app/store/engine/bolt_accessor_test.go
+++ b/app/store/engine/bolt_accessor_test.go
@@ -74,6 +74,9 @@ func TestBoltDB_Put(t *testing.T) {
 
 	err = b.Put(store.Locator{URL: "https://radio-t.com", SiteID: "bad"}, comment)
 	assert.EqualError(t, err, `site "bad" not found`)
+
+	err = b.Put(store.Locator{URL: "https://radio-t.com-bad", SiteID: "radio-t"}, comment)
+	assert.EqualError(t, err, `no bucket https://radio-t.com-bad in store`)
 }
 
 func TestBoltDB_Last(t *testing.T) {
@@ -219,6 +222,11 @@ func TestBoltDB_Ref(t *testing.T) {
 
 	_, _, err = b.parseRef([]byte("https://radio-t.com/2"))
 	assert.NotNil(t, err)
+}
+
+func TestBoltDB_New(t *testing.T) {
+	_, err := NewBoltDB(bolt.Options{}, BoltSite{FileName: "/dev/nul", SiteID: "radio-t"})
+	assert.EqualError(t, err, "failed to make boltdb for /dev/nul: open /dev/nul: operation not permitted")
 }
 
 // makes new boltdb, put two records

--- a/app/store/engine/bolt_accessor_test.go
+++ b/app/store/engine/bolt_accessor_test.go
@@ -128,21 +128,26 @@ func TestBoltDB_List(t *testing.T) {
 	_, err := b.Create(comment)
 	assert.Nil(t, err)
 
+	ts := func(sec int) time.Time { return time.Date(2017, 12, 20, 15, 18, sec, 0, time.Local) }
+
 	res, err := b.List("radio-t", 0, 0)
 	assert.Nil(t, err)
-	assert.Equal(t, []store.PostInfo{{URL: "https://radio-t.com/2", Count: 1}, {URL: "https://radio-t.com", Count: 2}}, res)
+	assert.Equal(t, []store.PostInfo{{URL: "https://radio-t.com/2", Count: 1, FirstTS: ts(22), LastTS: ts(22)},
+		{URL: "https://radio-t.com", Count: 2, FirstTS: ts(22), LastTS: ts(23)}},
+		res)
 
 	res, err = b.List("radio-t", -1, -1)
 	assert.Nil(t, err)
-	assert.Equal(t, []store.PostInfo{{URL: "https://radio-t.com/2", Count: 1}, {URL: "https://radio-t.com", Count: 2}}, res)
+	assert.Equal(t, []store.PostInfo{{URL: "https://radio-t.com/2", Count: 1, FirstTS: ts(22), LastTS: ts(22)},
+		{URL: "https://radio-t.com", Count: 2, FirstTS: ts(22), LastTS: ts(23)}}, res)
 
 	res, err = b.List("radio-t", 1, 0)
 	assert.Nil(t, err)
-	assert.Equal(t, []store.PostInfo{{URL: "https://radio-t.com/2", Count: 1}}, res)
+	assert.Equal(t, []store.PostInfo{{URL: "https://radio-t.com/2", Count: 1, FirstTS: ts(22), LastTS: ts(22)}}, res)
 
 	res, err = b.List("radio-t", 1, 1)
 	assert.Nil(t, err)
-	assert.Equal(t, []store.PostInfo{{URL: "https://radio-t.com", Count: 2}}, res)
+	assert.Equal(t, []store.PostInfo{{URL: "https://radio-t.com", Count: 2, FirstTS: ts(22), LastTS: ts(23)}}, res)
 
 	res, err = b.List("bad", 1, 1)
 	assert.EqualError(t, err, `site "bad" not found`)

--- a/app/store/engine/bolt_admin.go
+++ b/app/store/engine/bolt_admin.go
@@ -28,8 +28,8 @@ func (b *BoltDB) Delete(locator store.Locator, commentID string, mode store.Dele
 			return e
 		}
 
-		comment, err := b.load(postBkt, []byte(commentID))
-		if err != nil {
+		comment := store.Comment{}
+		if err := b.load(postBkt, []byte(commentID), &comment); err != nil {
 			return errors.Wrapf(err, "can't load key %s from bucket %s", commentID, locator.URL)
 		}
 		// set deleted status and clear fields
@@ -63,7 +63,7 @@ func (b *BoltDB) DeleteAll(siteID string) error {
 	}
 
 	// delete all buckets except blocked users
-	toDelete := []string{postsBucketName, lastBucketName, userBucketName, countsBucketName}
+	toDelete := []string{postsBucketName, lastBucketName, userBucketName, infoBucketName}
 
 	// delete top-level buckets
 	err = bdb.Update(func(tx *bolt.Tx) error {

--- a/app/store/engine/bolt_admin.go
+++ b/app/store/engine/bolt_admin.go
@@ -217,3 +217,42 @@ func (b *BoltDB) Blocked(siteID string) (users []store.BlockedUser, err error) {
 
 	return users, err
 }
+
+// SetReadOnly makes post read-only or reset the ro flag
+func (b *BoltDB) SetReadOnly(locator store.Locator, status bool) error {
+	bdb, err := b.db(locator.SiteID)
+	if err != nil {
+		return err
+	}
+
+	return bdb.Update(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket([]byte(readonlyBucketName))
+		switch status {
+		case true:
+			if e := bucket.Put([]byte(locator.URL), []byte(time.Now().Format(tsNano))); e != nil {
+				return errors.Wrapf(e, "failed to set ro for %s to %s", locator.URL, status)
+			}
+		case false:
+			if e := bucket.Delete([]byte(locator.URL)); e != nil {
+				return errors.Wrapf(e, "failed to clean ro for %s", locator.URL)
+			}
+		}
+		return nil
+	})
+}
+
+// IsReadOnly checks if user blocked
+func (b *BoltDB) IsReadOnly(locator store.Locator) (ro bool) {
+
+	bdb, err := b.db(locator.SiteID)
+	if err != nil {
+		return false
+	}
+
+	_ = bdb.View(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket([]byte(readonlyBucketName))
+		ro = bucket.Get([]byte(locator.URL)) != nil
+		return nil
+	})
+	return ro
+}

--- a/app/store/engine/bolt_admin_test.go
+++ b/app/store/engine/bolt_admin_test.go
@@ -4,9 +4,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/umputun/remark/app/store"
 )

--- a/app/store/engine/bolt_admin_test.go
+++ b/app/store/engine/bolt_admin_test.go
@@ -43,6 +43,10 @@ func TestBoltDB_Delete(t *testing.T) {
 	loc.SiteID = "bad"
 	err = b.Delete(loc, res[0].ID, store.SoftDelete)
 	assert.EqualError(t, err, `site "bad" not found`)
+
+	loc = store.Locator{URL: "https://radio-t.com/bad", SiteID: "radio-t"}
+	err = b.Delete(loc, res[0].ID, store.SoftDelete)
+	assert.EqualError(t, err, `no bucket https://radio-t.com/bad in store`)
 }
 
 func TestBoltDB_DeleteHard(t *testing.T) {
@@ -112,6 +116,9 @@ func TestBoltDB_DeleteUser(t *testing.T) {
 	comments, err := b.Last("radio-t", 10)
 	assert.Nil(t, err)
 	assert.Equal(t, 0, len(comments), "nothing left")
+
+	err = b.DeleteUser("radio-t-bad", "user1")
+	assert.EqualError(t, err, `site "radio-t-bad" not found`)
 }
 
 func TestBoltDB_BlockUser(t *testing.T) {
@@ -130,6 +137,8 @@ func TestBoltDB_BlockUser(t *testing.T) {
 
 	assert.EqualError(t, b.SetBlock("bad", "user1", true), `site "bad" not found`)
 	assert.NoError(t, b.SetBlock("radio-t", "userX", false))
+
+	assert.False(t, b.IsBlocked("radio-t-bad", "user1"), "nothing blocked on wrong site")
 }
 
 func TestBoltDB_BlockList(t *testing.T) {

--- a/app/store/engine/engine.go
+++ b/app/store/engine/engine.go
@@ -27,6 +27,7 @@ type Accessor interface {
 	User(siteID string, userID string, limit int) ([]store.Comment, int, error) // comments by user, sorted by time
 	Count(locator store.Locator) (int, error)                                   // number of comments for the post
 	List(siteID string, limit int, skip int) ([]store.PostInfo, error)          // list of commented posts
+	Info(locator store.Locator) (store.PostInfo, error)                         // get post info
 }
 
 // Admin defines all store ops avail for admin only

--- a/app/store/engine/engine.go
+++ b/app/store/engine/engine.go
@@ -27,7 +27,7 @@ type Accessor interface {
 	User(siteID string, userID string, limit int) ([]store.Comment, int, error) // comments by user, sorted by time
 	Count(locator store.Locator) (int, error)                                   // number of comments for the post
 	List(siteID string, limit int, skip int) ([]store.PostInfo, error)          // list of commented posts
-	Info(locator store.Locator) (store.PostInfo, error)                         // get post info
+	Info(locator store.Locator, readonlyAge int) (store.PostInfo, error)        // get post info
 }
 
 // Admin defines all store ops avail for admin only

--- a/app/store/engine/engine.go
+++ b/app/store/engine/engine.go
@@ -38,6 +38,8 @@ type Admin interface {
 	SetBlock(siteID string, userID string, status bool) error                    // block or unblock  user
 	IsBlocked(siteID string, userID string) bool                                 // check if user blocked
 	Blocked(siteID string) ([]store.BlockedUser, error)                          // get list of blocked users
+	SetReadOnly(locator store.Locator, status bool) error                        // set/reset read-only flag
+	IsReadOnly(locator store.Locator) bool                                       // check if post read-only
 }
 
 // sortComments is for engines can't sort data internally

--- a/remark.rest
+++ b/remark.rest
@@ -102,7 +102,7 @@ GET {{host}}/api/v1/admin/blocked?site=remark
 DELETE {{host}}/api/v1/admin/comment/3665976683?site=remark&url=https://remark42.com/demo/
 
 ### get post info
-GET {{host}}/api/v1/info?site=remark&url=https://radio-t.com/blah1
+GET {{host}}/api/v1/info?site=remark&url=https://remark42.com/demo/
 
 ### post rss
 GET {{host}}/api/v1/rss/post?site=remark&url=https://remark42.com/demo/

--- a/remark.rest
+++ b/remark.rest
@@ -1,6 +1,6 @@
 
 ### find request with tree
-GET {{host}}/api/v1/find?site=remark&sort=-active&format=tree&url=https://remark42.com/demo/
+GET {{host}}/api/v1/find?site=radiot&sort=-active&format=tree&url=https://radio-t.com/p/2018/05/05/podcast-596/
 
 ### find request with plain
 GET {{host}}/api/v1/find?site=remark&sort=-score&format=plain&url=https://remark42.com/demo/
@@ -84,7 +84,7 @@ Content-Type: application/json
 ]
 
 ### list commented posts
-GET {{host}}/api/v1/list?site=remark&limit=10&skip=5
+GET {{host}}/api/v1/list?site=radiot&limit=10&skip=5
 
 ### get config
 GET {{host}}/api/v1/config
@@ -102,7 +102,7 @@ GET {{host}}/api/v1/admin/blocked?site=remark
 DELETE {{host}}/api/v1/admin/comment/3665976683?site=remark&url=https://remark42.com/demo/
 
 ### get post info
-GET {{host}}/api/v1/info?site=remark&url=https://remark42.com/demo/
+GET {{host}}/api/v1/info?site=radiot&url=https://radio-t.com/p/2018/05/05/podcast-596/
 
 ### post rss
 GET {{host}}/api/v1/rss/post?site=remark&url=https://remark42.com/demo/

--- a/remark.rest
+++ b/remark.rest
@@ -101,6 +101,8 @@ GET {{host}}/api/v1/admin/blocked?site=remark
 ### delete comment by id
 DELETE {{host}}/api/v1/admin/comment/3665976683?site=remark&url=https://remark42.com/demo/
 
+### get post info
+GET {{host}}/api/v1/info?site=remark&url=https://radio-t.com/blah1
 
 ### post rss
 GET {{host}}/api/v1/rss/post?site=remark&url=https://remark42.com/demo/

--- a/remark.rest
+++ b/remark.rest
@@ -3,7 +3,7 @@
 GET {{host}}/api/v1/find?site=radiot&sort=-active&format=tree&url=https://radio-t.com/p/2018/05/05/podcast-596/
 
 ### find request with plain
-GET {{host}}/api/v1/find?site=remark&sort=-score&format=plain&url=https://remark42.com/demo/
+GET {{host}}/api/v1/find?site=radiot&sort=-time&format=plain&url=https://radio-t.com/p/2018/05/08/prep-597/
 
 ### last 50 comments
 GET {{host}}/api/v1/last/50?site=remark
@@ -102,7 +102,7 @@ GET {{host}}/api/v1/admin/blocked?site=remark
 DELETE {{host}}/api/v1/admin/comment/3665976683?site=remark&url=https://remark42.com/demo/
 
 ### get post info
-GET {{host}}/api/v1/info?site=radiot&url=https://radio-t.com/p/2018/05/05/podcast-596/
+GET {{host}}/api/v1/info?site=radiot&url=https://radio-t.com/p/2018/05/08/prep-597/
 
 ### post rss
 GET {{host}}/api/v1/rss/post?site=remark&url=https://remark42.com/demo/

--- a/scripts/create-backup.sh
+++ b/scripts/create-backup.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# this scrips makes a backup file to /srv/var/userbackup-<site>-<timestamp>.gz
+
+backup_file=${BACKUP_PATH}/userbackup-${1}-$(date +%s).gz
+echo "make backup file for site $1 to $backup_file"
+curl "http://127.0.0.1:8081/api/v1/admin/export?site=${1}&secret=${SECRET}" > ${backup_file}

--- a/scripts/create-backup.sh
+++ b/scripts/create-backup.sh
@@ -2,6 +2,7 @@
 
 # this scrips makes a backup file to /srv/var/userbackup-<site>-<timestamp>.gz
 
+BACKUP_PATH=${BACKUP_PATH:-./var}
 backup_file=${BACKUP_PATH}/userbackup-${1}-$(date +%s).gz
 echo "make backup file for site $1 to $backup_file"
 curl "http://127.0.0.1:8081/api/v1/admin/export?site=${1}&secret=${SECRET}" > ${backup_file}

--- a/scripts/migrate-data.sh
+++ b/scripts/migrate-data.sh
@@ -1,13 +1,23 @@
 #!/bin/sh
+
+# this scrips making a backup file to /tmp/export-remark.gz and loading it back
+# useful to migrate data schema in case if new version of data store incomaptible with the stored comments.
+
 echo "make backup file for site $1"
 curl "http://127.0.0.1:8081/api/v1/admin/export?site=${1}&secret=${SECRET}" > /tmp/export-remark.gz
+
+BOLTDB_PATH=${BOLTDB_PATH:-./var}
+BACKUP_PATH=${BACKUP_PATH:-./var}
+
+cp ${BOLTDB_PATH}/${1}.db ${BACKUP_PATH}/${1}-$(date +%s).db
 
 echo "import backup to site $1"
 echo "unpack /tmp/export-remark.gz"
 gunzip -c /tmp/export-remark.gz >/tmp/backup.remark
+ls -laH /tmp/backup.remark
 
-size=`stat -c "%s" /tmp/backup.remark`
-echo "source file size ${size}"
-
+echo "export to site $1"
 curl -X POST -H "Content-Type: application/json" --data-binary @/tmp/backup.remark "http://127.0.0.1:8081/api/v1/admin/import?site=${1}&provider=native&secret=${SECRET}"
-rm -fq /tmp/backup.remark
+
+rm -f /tmp/backup.remark
+rm -f /tmp/export-remark.gz

--- a/scripts/migrate-data.sh
+++ b/scripts/migrate-data.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+echo "make backup file for site $1"
+curl "http://127.0.0.1:8081/api/v1/admin/export?site=${1}&secret=${SECRET}" > /tmp/export-remark.gz
+
+echo "import backup to site $1"
+echo "unpack /tmp/export-remark.gz"
+gunzip -c /tmp/export-remark.gz >/tmp/backup.remark
+
+size=`stat -c "%s" /tmp/backup.remark`
+echo "source file size ${size}"
+
+curl -X POST -H "Content-Type: application/json" --data-binary @/tmp/backup.remark "http://127.0.0.1:8081/api/v1/admin/import?site=${1}&provider=native&secret=${SECRET}"
+rm -fq /tmp/backup.remark

--- a/scripts/restore-backup.sh
+++ b/scripts/restore-backup.sh
@@ -7,5 +7,5 @@ gunzip -c /srv/var/backup/$1 >/tmp/backup.remark
 size=`stat -c "%s" /tmp/backup.remark`
 echo "source file size ${size}"
 
-curl -X POST -H "Content-Type: application/json" -d @/tmp/backup.remark "http://127.0.0.1:8081/api/v1/admin/import?site=${2}&provider=native&secret=${SECRET}"
+curl -X POST -H "Content-Type: application/json" --data-binary @/tmp/backup.remark "http://127.0.0.1:8081/api/v1/admin/import?site=${2}&provider=native&secret=${SECRET}"
 rm -fq /tmp/backup.remark


### PR DESCRIPTION
backend changes for #55 

- new parameter `READONLY_AGE`, default 0 (disabled)
- change `count` bucket to more generic `info` and here post info
- extend post info with first & last ts for the post
- add new bucket `readonly` to keep posts manually marked as ro
- add new rest method to set/reset read-only
- add new rest method to get post info
- create method rejects attempts to modify RO post

_This change requires storage migration._
