### PR TITLE
lint: misspell, ineffassign

### DIFF
--- a/app/rest/api/rss_test.go
+++ b/app/rest/api/rss_test.go
@@ -48,7 +48,7 @@ func TestServer_RssPost(t *testing.T) {
 	expected, res = cleanRssFormatting(expected, res)
 	assert.Equal(t, expected, res)
 
-	res, code = get(t, ts.URL+"/api/v1/rss/post?site=radio-t-bad&url=https://radio-t.com/blah1")
+	_, code = get(t, ts.URL+"/api/v1/rss/post?site=radio-t-bad&url=https://radio-t.com/blah1")
 	assert.Equal(t, 400, code)
 }
 

--- a/app/store/engine/bolt_accessor_test.go
+++ b/app/store/engine/bolt_accessor_test.go
@@ -29,7 +29,7 @@ func TestBoltDB_CreateAndFind(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Equal(t, "key id-1 already in store", err.Error())
 
-	res, err = b.Find(store.Locator{URL: "https://radio-t.com", SiteID: "radio-t-bad"}, "time")
+	_, err = b.Find(store.Locator{URL: "https://radio-t.com", SiteID: "radio-t-bad"}, "time")
 	assert.EqualError(t, err, `site "radio-t-bad" not found`)
 }
 
@@ -173,7 +173,7 @@ func TestBoltDB_List(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, []store.PostInfo{{URL: "https://radio-t.com", Count: 2, FirstTS: ts(22), LastTS: ts(23)}}, res)
 
-	res, err = b.List("bad", 1, 1)
+	_, err = b.List("bad", 1, 1)
 	assert.EqualError(t, err, `site "bad" not found`)
 }
 

--- a/app/store/engine/bolt_admin.go
+++ b/app/store/engine/bolt_admin.go
@@ -82,7 +82,7 @@ func (b *BoltDB) DeleteAll(siteID string) error {
 	return errors.Wrapf(err, "failed to delete top level buckets fro site %s", siteID)
 }
 
-// DeleteUser removes all comments for given user. Everyting will be market as deleted
+// DeleteUser removes all comments for given user. Everything will be market as deleted
 // and user name and userID will be changed to "deleted". Also removes from last and from user buckets.
 func (b *BoltDB) DeleteUser(siteID string, userID string) error {
 	bdb, err := b.db(siteID)


### PR DESCRIPTION
Minor fixes for goreportcard.