### PR TITLE
refactor Github OAuth provider

### DIFF
--- a/app/rest/auth/provider.go
+++ b/app/rest/auth/provider.go
@@ -48,7 +48,8 @@ type Params struct {
 type userData map[string]interface{}
 
 func (u userData) value(key string) string {
-	if val, ok := u[key]; ok {
+	// json.Unmarshal converts json "null" value to go's "nil", in this case return empty string
+	if val, ok := u[key]; ok && val != nil {
 		return fmt.Sprintf("%v", val)
 	}
 	return ""

--- a/app/rest/auth/providers.go
+++ b/app/rest/auth/providers.go
@@ -35,7 +35,6 @@ func NewGoogle(p Params) Provider {
 
 // NewGithub makes github oauth2 provider
 func NewGithub(p Params) Provider {
-
 	return initProvider(p, Provider{
 		Name:        "github",
 		Endpoint:    github.Endpoint,
@@ -49,11 +48,8 @@ func NewGithub(p Params) Provider {
 				Picture: data.value("avatar_url"),
 			}
 			// github may have no user name, use login in this case
-			if userInfo.Name == "<nil>" {
-				userInfo.Name = data.value("login")
-			}
 			if userInfo.Name == "" {
-				userInfo.Name = userInfo.ID[0:16]
+				userInfo.Name = data.value("login")
 			}
 			return userInfo
 		},

--- a/app/rest/auth/providers_test.go
+++ b/app/rest/auth/providers_test.go
@@ -32,16 +32,10 @@ func TestProviders_NewGithub(t *testing.T) {
 	assert.Equal(t, store.User{Name: "test user", ID: "github_e80b2d2608711cbb3312db7c4727a46fbad9601a",
 		Picture: "http://demo.remark42.com/blah.png", Admin: false, Blocked: false, IP: ""}, user, "got %+v", user)
 
-	// nil name in data
-	udata = userData{"login": "lll", "name": "<nil>", "avatar_url": "http://demo.remark42.com/blah.png"}
+	// nil name in data (json response contains `"name": null`); using login, it's always required
+	udata = userData{"login": "lll", "name": nil, "avatar_url": "http://demo.remark42.com/blah.png"}
 	user = r.MapUser(udata, nil)
 	assert.Equal(t, store.User{Name: "lll", ID: "github_e80b2d2608711cbb3312db7c4727a46fbad9601a",
-		Picture: "http://demo.remark42.com/blah.png", Admin: false, Blocked: false, IP: ""}, user, "got %+v", user)
-
-	// no name in data
-	udata = userData{"login": "lll", "avatar_url": "http://demo.remark42.com/blah.png"}
-	user = r.MapUser(udata, nil)
-	assert.Equal(t, store.User{Name: "github_e80b2d260", ID: "github_e80b2d2608711cbb3312db7c4727a46fbad9601a",
 		Picture: "http://demo.remark42.com/blah.png", Admin: false, Blocked: false, IP: ""}, user, "got %+v", user)
 }
 


### PR DESCRIPTION
I checked out the github API response for user profile. If user left his profile name empty, `"user": null` returns in the response. When go's `json.Unmarshal` decodes json `null` value it converts it to `nil`. So I refactored method `value()` of `userData` struct in `remark/app/rest/auth/provider.go` to avoid checking string `"<nil>"` in github provider.

(from PR #64)