### PR TITLE
add link shortening #79

### DIFF
--- a/app/store/comment_test.go
+++ b/app/store/comment_test.go
@@ -16,11 +16,21 @@ func TestComment_Sanitize(t *testing.T) {
 		{inp: Comment{}, out: Comment{}},
 		{
 			inp: Comment{
-				Text: `blah <a href="javascript:alert('XSS1')" onmouseover="alert('XSS2')">XSS<a>` + "\n\t",
+				Text: `blah <a href="javascript:alert('XSS1')" onmouseover="alert('XSS2')">XSS</a>` + "\n\t",
 				User: User{ID: `<a href="http://blah.com">username</a>`},
 			},
 			out: Comment{
 				Text: "blah XSS\n\t",
+				User: User{ID: `&lt;a href=&#34;http://blah.com&#34;&gt;username&lt;/a&gt;`},
+			},
+		},
+		{
+			inp: Comment{
+				Text: `blah <a href="https://www.reddit.com/r/golang/comments/8jdo2l/remark42_is_a_selfhosted_lightweight_and_simple/">https://www.reddit.com/r/golang/comments/8jdo2l/remark42_is_a_selfhosted_lightweight_and_simple/</a>` + "\n\t",
+				User: User{ID: `<a href="http://blah.com">username</a>`},
+			},
+			out: Comment{
+				Text: `blah <a href="https://www.reddit.com/r/golang/comments/8jdo2l/remark42_is_a_selfhosted_lightweight_and_simple/" rel="nofollow">https://www.reddit.com/r/gola...</a>` + "\n\t",
 				User: User{ID: `&lt;a href=&#34;http://blah.com&#34;&gt;username&lt;/a&gt;`},
 			},
 		},
@@ -109,4 +119,47 @@ func TestComment_SetDeletedHard(t *testing.T) {
 	assert.Nil(t, comment.Edit)
 	assert.False(t, comment.Pin)
 	assert.Equal(t, User{Name: "deleted", ID: "deleted", Picture: "", Admin: false, Blocked: false, IP: ""}, comment.User)
+}
+
+func TestComment_ShortenAutoLinks(t *testing.T) {
+	tbl := []struct {
+		max     int
+		in, out string
+	}{
+		{32, "", ""},
+		{32, "text", "text"},
+		{32, "<p>asd</p>", "<p>asd</p>"},
+		{5, `<a href="incorrect-url">incorrect-url</a>`, `<a href="incorrect-url">incorrect-url</a>`},
+		{32, `<a href="https://blah.com">some text, not href</a>`, `<a href="https://blah.com">some text, not href</a>`},
+		{
+			32,
+			`<a href="https://blah.com/a/b/c/d?g=123#anc">https://blah.com/a/b/c/d?g=123#anc</a>`,
+			`<a href="https://blah.com/a/b/c/d?g=123#anc">https://blah.com/a/b/c/d?g=123#anc</a>`,
+		},
+		{
+			31,
+			`<a href="https://blah.com/a/b/c/d?g=123#anc">https://blah.com/a/b/c/d?g=123#anc</a>`,
+			`<a href="https://blah.com/a/b/c/d?g=123#anc">https://blah.com/a/b/c/d?g=1...</a>`,
+		},
+		{
+			15,
+			`<a href="https://blah.com/a/b/c/d?g=123#anc">https://blah.com/a/b/c/d?g=123#anc</a>`,
+			`<a href="https://blah.com/a/b/c/d?g=123#anc">https://blah.com...</a>`,
+		},
+		{
+			3,
+			`<a href="https://blah.com/a/b/c/d?g=123#anc">https://blah.com/a/b/c/d?g=123#anc</a>`,
+			`<a href="https://blah.com/a/b/c/d?g=123#anc">https://blah.com...</a>`,
+		},
+		{
+			-1,
+			`<a href="https://blah.com/a/b/c/d?g=123#anc">https://blah.com/a/b/c/d?g=123#anc</a>`,
+			`<a href="https://blah.com/a/b/c/d?g=123#anc">https://blah.com/a/b/c/d?g=123#anc</a>`,
+		},
+	}
+
+	for n, tt := range tbl {
+		got := shortenAutoLinks(tt.in, tt.max)
+		assert.Equalf(t, tt.out, got, "check #%d", n)
+	}
 }


### PR DESCRIPTION
All automatic links (link "href" == link "text") with URL longer than `const shortURLLen = 32` (from comment.go) are shortened during `comment.Sanitize()`.