### PR TITLE
feature/block ttl

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,13 +428,13 @@ Sort can be `time`, `active` or `score`. Supported sort order with prefix -/+, i
 ### Admin
 
 * `DELETE /api/v1/admin/comment/{id}?site=site-id&url=post-url` - delete comment by `id`.
-* `PUT /api/v1/admin/user/{userid}?site=site-id&block=1` - block or unblock user.
-* `GET api/v1/admin/blocked&site=site-id` - list of blocked user ids.
+* `PUT /api/v1/admin/user/{userid}?site=site-id&block=1&ttl=7d` - block or unblock user with optional ttl (default=permanent)
+* `GET api/v1/admin/blocked&site=site-id` - list of blocked user ids
   ```go
   type BlockedUser struct {
       ID        string    `json:"id"`
       Name      string    `json:"name"`
-      Timestamp time.Time `json:"time"`
+      Until     time.Time `json:"time"`
   }
   ```
 * `GET /api/v1/admin/export?site=side-id&mode=[stream|file]` - export all comments to json stream or gz file.

--- a/backend/app/rest/api/admin.go
+++ b/backend/app/rest/api/admin.go
@@ -117,13 +117,20 @@ func (a *admin) deleteMeRequestCtrl(w http.ResponseWriter, r *http.Request) {
 	render.JSON(w, r, JSON{"user_id": claims.User.ID, "site_id": claims.SiteID})
 }
 
-// PUT /user/{userid}?site=side-id&block=1 - block or unblock user
+// PUT /user/{userid}?site=side-id&block=1&ttl=7d - block or unblock user
 func (a *admin) setBlockCtrl(w http.ResponseWriter, r *http.Request) {
 	userID := chi.URLParam(r, "userid")
 	siteID := r.URL.Query().Get("site")
 	blockStatus := r.URL.Query().Get("block") == "1"
 
-	if err := a.dataService.SetBlock(siteID, userID, blockStatus); err != nil {
+	ttl := 0 * time.Nanosecond // unlimited duration by default
+	if ttlParam := r.URL.Query().Get("ttl"); ttlParam != "" {
+		if d, err := time.ParseDuration(ttlParam); err == nil {
+			ttl = d
+		}
+	}
+
+	if err := a.dataService.SetBlock(siteID, userID, blockStatus, ttl); err != nil {
 		rest.SendErrorJSON(w, r, http.StatusBadRequest, err, "can't set blocking status")
 		return
 	}

--- a/backend/app/rest/api/admin.go
+++ b/backend/app/rest/api/admin.go
@@ -123,7 +123,7 @@ func (a *admin) setBlockCtrl(w http.ResponseWriter, r *http.Request) {
 	siteID := r.URL.Query().Get("site")
 	blockStatus := r.URL.Query().Get("block") == "1"
 
-	ttl := 0 * time.Nanosecond // unlimited duration by default
+	ttl := time.Duration(0) // unlimited duration by default
 	if ttlParam := r.URL.Query().Get("ttl"); ttlParam != "" {
 		if d, err := time.ParseDuration(ttlParam); err == nil {
 			ttl = d

--- a/backend/app/store/comment.go
+++ b/backend/app/store/comment.go
@@ -50,9 +50,9 @@ type PostInfo struct {
 
 // BlockedUser holds id and ts for blocked user
 type BlockedUser struct {
-	ID        string    `json:"id"`
-	Name      string    `json:"name"`
-	Timestamp time.Time `json:"time"`
+	ID    string    `json:"id"`
+	Name  string    `json:"name"`
+	Until time.Time `json:"time"`
 }
 
 // DeleteMode defines how much comment info will be erased

--- a/backend/app/store/engine/bolt_admin.go
+++ b/backend/app/store/engine/bolt_admin.go
@@ -3,7 +3,6 @@ package engine
 import (
 	"encoding/json"
 	"log"
-	"strings"
 	"time"
 
 	"github.com/coreos/bbolt"
@@ -241,22 +240,6 @@ func (b *BoltDB) Blocked(siteID string) (users []store.BlockedUser, err error) {
 	})
 
 	return users, err
-}
-
-func (b *BoltDB) parseBlockValue(val string) (from, to time.Time, err error) {
-	parts := strings.Split(string(val), "!!")
-	if from, err = time.Parse(tsNano, parts[0]); err != nil {
-		return time.Time{}, time.Time{}, errors.Wrapf(err, "can't parse from=%s", parts[0])
-	}
-
-	if len(parts) < 2 {
-		return from, time.Time{}, nil
-	}
-
-	if to, err = time.Parse(tsNano, parts[1]); err != nil {
-		return time.Time{}, time.Time{}, errors.Wrapf(err, "can't parse to=%s", parts[1])
-	}
-	return from, to, nil
 }
 
 // SetReadOnly makes post read-only or reset the ro flag

--- a/backend/app/store/engine/bolt_admin.go
+++ b/backend/app/store/engine/bolt_admin.go
@@ -155,7 +155,8 @@ func (b *BoltDB) DeleteUser(siteID string, userID string) error {
 	return err
 }
 
-// SetBlock blocks/unblocks user for given site
+// SetBlock blocks/unblocks user for given site. ttl defines for for how long, 0 - permanent
+// block uses blocksBucketName with key=userID and val=TTL+now
 func (b *BoltDB) SetBlock(siteID string, userID string, status bool, ttl time.Duration) error {
 
 	bdb, err := b.db(siteID)
@@ -167,7 +168,7 @@ func (b *BoltDB) SetBlock(siteID string, userID string, status bool, ttl time.Du
 		bucket := tx.Bucket([]byte(blocksBucketName))
 		switch status {
 		case true:
-			val := time.Now().AddDate(100, 0, 0).Format(tsNano)
+			val := time.Now().AddDate(100, 0, 0).Format(tsNano) // permanent is 50year
 			if ttl > 0 {
 				val = time.Now().Add(ttl).Format(tsNano)
 			}

--- a/backend/app/store/engine/engine.go
+++ b/backend/app/store/engine/engine.go
@@ -5,6 +5,7 @@ package engine
 import (
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/umputun/remark/backend/app/store"
 )
@@ -44,7 +45,7 @@ type Admin interface {
 	Delete(locator store.Locator, commentID string, mode store.DeleteMode) error // delete comment by id
 	DeleteAll(siteID string) error                                               // delete all data from site
 	DeleteUser(siteID string, userID string) error                               // remove all comments from user
-	SetBlock(siteID string, userID string, status bool) error                    // block or unblock  user
+	SetBlock(siteID string, userID string, status bool, ttl time.Duration) error // block or unblock  user
 	IsBlocked(siteID string, userID string) bool                                 // check if user blocked
 	Blocked(siteID string) ([]store.BlockedUser, error)                          // get list of blocked users
 	SetReadOnly(locator store.Locator, status bool) error                        // set/reset read-only flag

--- a/backend/app/store/engine/engine.go
+++ b/backend/app/store/engine/engine.go
@@ -45,7 +45,7 @@ type Admin interface {
 	Delete(locator store.Locator, commentID string, mode store.DeleteMode) error // delete comment by id
 	DeleteAll(siteID string) error                                               // delete all data from site
 	DeleteUser(siteID string, userID string) error                               // remove all comments from user
-	SetBlock(siteID string, userID string, status bool, ttl time.Duration) error // block or unblock  user
+	SetBlock(siteID string, userID string, status bool, ttl time.Duration) error // block or unblock user with TTL (0-permanent)
 	IsBlocked(siteID string, userID string) bool                                 // check if user blocked
 	Blocked(siteID string) ([]store.BlockedUser, error)                          // get list of blocked users
 	SetReadOnly(locator store.Locator, status bool) error                        // set/reset read-only flag


### PR DESCRIPTION
see #88 

**important**:  this change compatible with the existing data structure but treats `time` (bucket value) differently as "blocked until". Deploying the change will effectively unblock all currently blocked users. 

Not sure how real is this issue, but I'm thinking about adding some migration code converting all blocked users to "permanent" by setting `time` to today+50years