### PR TITLE
ISSUE-73: UI support for DeleteMe request

### DIFF
--- a/web/app/common/api.js
+++ b/web/app/common/api.js
@@ -76,6 +76,11 @@ export const deleteMe = () =>
     url: `/deleteme?site=${siteId}`,
   });
 
+export const approveDeleteMe = token =>
+  fetcher.get({
+    url: `/admin/deleteme?token=${token}`,
+  });
+
 /* admin */
 export const pinComment = ({ id, url }) =>
   fetcher.put({

--- a/web/app/common/api.js
+++ b/web/app/common/api.js
@@ -69,6 +69,13 @@ export const getUser = () =>
     withCredentials: true,
   });
 
+/* GDPR */
+
+export const deleteMe = () =>
+  fetcher.post({
+    url: `/deleteme?site=${siteId}`,
+  });
+
 /* admin */
 export const pinComment = ({ id, url }) =>
   fetcher.put({

--- a/web/app/common/constants.js
+++ b/web/app/common/constants.js
@@ -1,24 +1,24 @@
-const BASE_URL = process.env.REMARK_URL;
-const API_BASE = '/api/v1';
-const NODE_ID = process.env.REMARK_NODE;
-const COUNTER_NODE_CLASSNAME = 'remark42__counter';
-const COMMENT_NODE_CLASSNAME_PREFIX = 'remark42__comment-';
-const LAST_COMMENTS_NODE_CLASSNAME = 'remark42__last-comments';
-const DEFAULT_LAST_COMMENTS_MAX = 15;
-const DEFAULT_MAX_COMMENT_SIZE = 1000;
-const MAX_SHOWN_ROOT_COMMENTS = 10;
-const DEFAULT_SORT = '-score';
-const PROVIDER_NAMES = {
+export const BASE_URL = process.env.REMARK_URL;
+export const API_BASE = '/api/v1';
+export const NODE_ID = process.env.REMARK_NODE;
+export const COUNTER_NODE_CLASSNAME = 'remark42__counter';
+export const COMMENT_NODE_CLASSNAME_PREFIX = 'remark42__comment-';
+export const LAST_COMMENTS_NODE_CLASSNAME = 'remark42__last-comments';
+export const DEFAULT_LAST_COMMENTS_MAX = 15;
+export const DEFAULT_MAX_COMMENT_SIZE = 1000;
+export const MAX_SHOWN_ROOT_COMMENTS = 10;
+export const DEFAULT_SORT = '-score';
+export const PROVIDER_NAMES = {
   google: 'Google',
   facebook: 'Facebook',
   github: 'GitHub',
   yandex: 'Yandex',
   dev: 'Dev',
 };
-const LS_COLLAPSE_KEY = '__remarkCollapsed';
-const LS_SORT_KEY = '__remarkSort';
+export const LS_COLLAPSE_KEY = '__remarkCollapsed';
+export const LS_SORT_KEY = '__remarkSort';
 
-const BLOCKING_DURATIONS = [
+export const BLOCKING_DURATIONS = [
   {
     label: 'Permanently',
     value: 'permanently',
@@ -36,20 +36,3 @@ const BLOCKING_DURATIONS = [
     value: `${60 * 24}m`,
   },
 ];
-
-module.exports = {
-  BASE_URL,
-  API_BASE,
-  NODE_ID,
-  COUNTER_NODE_CLASSNAME,
-  LAST_COMMENTS_NODE_CLASSNAME,
-  COMMENT_NODE_CLASSNAME_PREFIX,
-  DEFAULT_LAST_COMMENTS_MAX,
-  DEFAULT_MAX_COMMENT_SIZE,
-  MAX_SHOWN_ROOT_COMMENTS,
-  PROVIDER_NAMES,
-  DEFAULT_SORT,
-  LS_COLLAPSE_KEY,
-  LS_SORT_KEY,
-  BLOCKING_DURATIONS,
-};

--- a/web/app/common/fetcher.js
+++ b/web/app/common/fetcher.js
@@ -30,7 +30,7 @@ methods.forEach(method => {
 
       parameters.url = `${basename}${url}`;
 
-      if (method !== 'post' && !parameters.url.includes('?site=') && !parameters.url.includes('&site=')) {
+      if (siteId && method !== 'post' && !parameters.url.includes('?site=') && !parameters.url.includes('&site=')) {
         parameters.url += (parameters.url.includes('?') ? '&' : '?') + `site=${siteId}`;
       }
 

--- a/web/app/common/settings.js
+++ b/web/app/common/settings.js
@@ -11,3 +11,4 @@ const querySettings =
 export const siteId = querySettings['site_id'];
 export const url = querySettings['url'];
 export const maxShownComments = querySettings['max_shown_comments'];
+export const token = querySettings['token'];

--- a/web/app/components/auth-panel/__column/auth-panel__column.scss
+++ b/web/app/components/auth-panel/__column/auth-panel__column.scss
@@ -1,8 +1,6 @@
 .auth-panel__column {
   &:nth-child(1) {
-    overflow: hidden;
     font-weight: 700;
-    text-overflow: ellipsis;
   }
 
   &:nth-child(2) {

--- a/web/app/components/auth-panel/__sign-out/auth-panel__sign-out.scss
+++ b/web/app/components/auth-panel/__sign-out/auth-panel__sign-out.scss
@@ -1,0 +1,3 @@
+.auth-panel__sign-out {
+  margin-left: 5px;
+}

--- a/web/app/components/auth-panel/__tests__/auth-panel.test.js
+++ b/web/app/components/auth-panel/__tests__/auth-panel.test.js
@@ -48,7 +48,7 @@ describe('<AuthPanel />', () => {
 
       const userInfo = authPanelColumn[0];
 
-      expect(userInfo.textContent).toEqual(expect.stringContaining('You signed in as John. Sign out?'));
+      expect(userInfo.textContent).toEqual(expect.stringContaining('You signed in as John'));
     });
   });
   describe('For admin user', () => {

--- a/web/app/components/auth-panel/__user-id/auth-panel__user-id.jsx
+++ b/web/app/components/auth-panel/__user-id/auth-panel__user-id.jsx
@@ -1,0 +1,8 @@
+/** @jsx h */
+import { h } from 'preact';
+
+export default ({ id }) => (
+  <div className="auth-panel__user-id" title={id}>
+    {id}
+  </div>
+);

--- a/web/app/components/auth-panel/__user-id/auth-panel__user-id.scss
+++ b/web/app/components/auth-panel/__user-id/auth-panel__user-id.scss
@@ -1,3 +1,5 @@
 .auth-panel__user-id {
+  overflow: hidden;
+  text-overflow: ellipsis;
   color: #888;
 }

--- a/web/app/components/auth-panel/__username/auth-panel__username.scss
+++ b/web/app/components/auth-panel/__username/auth-panel__username.scss
@@ -1,3 +1,0 @@
-.auth-panel__username {
-  cursor: default;
-}

--- a/web/app/components/auth-panel/auth-panel.jsx
+++ b/web/app/components/auth-panel/auth-panel.jsx
@@ -1,14 +1,17 @@
 /** @jsx h */
 import { h, Component } from 'preact';
 
+import UserId from './__user-id/auth-panel__user-id';
+import Dropdown, { DropdownItem } from 'components/dropdown';
+import Button from 'components/button';
 import { PROVIDER_NAMES } from 'common/constants';
+import { requestDeletion } from 'utils/email';
 import { getHandleClickProps } from 'common/accessibility';
 
 export default class AuthPanel extends Component {
   constructor(props) {
     super(props);
 
-    this.toggleUserId = this.toggleUserId.bind(this);
     this.toggleBlockedVisibility = this.toggleBlockedVisibility.bind(this);
     this.toggleCommentsAvailability = this.toggleCommentsAvailability.bind(this);
     this.onSortChange = this.onSortChange.bind(this);
@@ -18,10 +21,6 @@ export default class AuthPanel extends Component {
     if (this.props.onSortChange) {
       this.props.onSortChange(e.target.value);
     }
-  }
-
-  toggleUserId() {
-    this.setState({ isUserIdVisible: !this.state.isUserIdVisible });
   }
 
   toggleBlockedVisibility() {
@@ -44,7 +43,12 @@ export default class AuthPanel extends Component {
     }
   }
 
-  render(props, { isUserIdVisible, isBlockedVisible }) {
+  getUserTitle() {
+    const { user } = this.props;
+    return <span className="auth-panel__username">{user.name}</span>;
+  }
+
+  render(props, { isBlockedVisible }) {
     const { user, providers = [], sort, isCommentsDisabled } = props;
 
     const sortArray = getSortArray(sort);
@@ -55,13 +59,20 @@ export default class AuthPanel extends Component {
         {loggedIn && (
           <div className="auth-panel__column">
             You signed in as{' '}
-            <strong {...getHandleClickProps(this.toggleUserId)} className="auth-panel__username">
-              {user.name}
-            </strong>
-            {isUserIdVisible && <span className="auth-panel__user-id"> ({user.id})</span>}.{' '}
-            <span {...getHandleClickProps(props.onSignOut)} className="auth-panel__pseudo-link" role="link">
+            <Dropdown title={user.name}>
+              <DropdownItem separator>
+                <UserId id={user.id} />
+              </DropdownItem>
+
+              <DropdownItem>
+                <Button mods={{ kind: 'link' }} onClick={requestDeletion}>
+                  Request my data removal
+                </Button>
+              </DropdownItem>
+            </Dropdown>{' '}
+            <Button className="auth-panel__sign-out" mods={{ kind: 'link' }} onClick={props.onSignOut}>
               Sign out?
-            </span>
+            </Button>
           </div>
         )}
 

--- a/web/app/components/auth-panel/auth-panel.jsx
+++ b/web/app/components/auth-panel/auth-panel.jsx
@@ -65,7 +65,7 @@ export default class AuthPanel extends Component {
               </DropdownItem>
 
               <DropdownItem>
-                <Button mods={{ kind: 'link' }} onClick={requestDeletion}>
+                <Button mods={{ kind: 'link' }} onClick={() => requestDeletion().then(props.onSignOut)}>
                   Request my data removal
                 </Button>
               </DropdownItem>

--- a/web/app/components/auth-panel/index.js
+++ b/web/app/components/auth-panel/index.js
@@ -7,7 +7,8 @@ require('./__pseudo-link/auth-panel__pseudo-link.scss');
 require('./__select/auth-panel__select.scss');
 require('./__select-label/auth-panel__select-label.scss');
 require('./__sort/auth-panel__sort.scss');
-require('./__username/auth-panel__username.scss');
+
 require('./__user-id/auth-panel__user-id.scss');
+require('./__sign-out/auth-panel__sign-out.scss');
 
 require('./_logged-in/auth-panel_logged-in.scss');

--- a/web/app/components/button/_focused/button_focused.scss
+++ b/web/app/components/button/_focused/button_focused.scss
@@ -1,0 +1,3 @@
+.button_focused:not(.button_clicked) {
+  outline-width: 5px;
+}

--- a/web/app/components/button/_kind/button_kind.scss
+++ b/web/app/components/button/_kind/button_kind.scss
@@ -1,0 +1,19 @@
+.button_kind_text {
+  border: none;
+  background: transparent;
+  padding: 0;
+}
+
+.button_kind_link {
+  border: none;
+  background: transparent;
+  padding: 0;
+
+  font-weight: 700;
+  white-space: nowrap;
+  color: #0aa;
+
+  &:hover {
+      color: #06c5c5;
+  }
+}

--- a/web/app/components/button/button.jsx
+++ b/web/app/components/button/button.jsx
@@ -1,0 +1,69 @@
+/** @jsx h */
+import { Component, h } from 'preact';
+import noop from '../../utils/noop';
+
+export default class Button extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      isClicked: false,
+      isFocused: false,
+    };
+
+    this.onMouseDown = this.onMouseDown.bind(this);
+    this.onFocus = this.onFocus.bind(this);
+    this.onBlur = this.onBlur.bind(this);
+  }
+
+  onMouseDown() {
+    this.setState({
+      isClicked: true,
+    });
+  }
+
+  onClick(e) {
+    this.props.onClick(e);
+  }
+
+  onBlur(e) {
+    this.setState({
+      isClicked: false,
+      isFocused: false,
+    });
+
+    this.props.onBlur(e);
+  }
+
+  onFocus(e) {
+    this.setState({
+      isFocused: true,
+    });
+
+    this.props.onFocus(e);
+  }
+
+  render(props, state) {
+    const { children, mix, mods, ...rest } = props;
+    const { isClicked, isFocused } = state;
+
+    return (
+      <button
+        {...rest}
+        className={b('button', { mix, mods }, { clicked: isClicked, focused: isFocused })}
+        onMouseDown={this.onMouseDown}
+        onBlur={this.onBlur}
+        onFocus={this.onFocus}
+      >
+        {children}
+      </button>
+    );
+  }
+}
+
+Button.defaultProps = {
+  type: 'button',
+  onClick: noop,
+  onBlur: noop,
+  onFocus: noop,
+};

--- a/web/app/components/button/button.scss
+++ b/web/app/components/button/button.scss
@@ -1,0 +1,6 @@
+.button {
+  cursor: pointer;
+  outline-width: 0;
+  font-size: inherit;
+  font-family: inherit;
+}

--- a/web/app/components/button/index.js
+++ b/web/app/components/button/index.js
@@ -1,0 +1,5 @@
+export { default } from './button';
+
+require('./button.scss');
+require('./_kind/button_kind.scss');
+require('./_focused/button_focused.scss');

--- a/web/app/components/dropdown/__content/dropdown__content.scss
+++ b/web/app/components/dropdown/__content/dropdown__content.scss
@@ -1,0 +1,14 @@
+.dropdown__content {
+  position: absolute;
+  z-index: 20;
+  outline-width: 0;
+  display: none;
+  top: 100%;
+  left: 50%;
+  transform: translate(-50%, 5px);
+  width: 170px;
+  background-color: #fff;
+  border: 2px solid #259c9a;
+  border-radius: 3px;
+  padding: 0 0 5px;
+}

--- a/web/app/components/dropdown/__item/dropdown__item.jsx
+++ b/web/app/components/dropdown/__item/dropdown__item.jsx
@@ -1,0 +1,8 @@
+/** @jsx h */
+import { h } from 'preact';
+
+export default function DropdownItem(props) {
+  const { children, separator = false, mix, mods } = props;
+
+  return <div className={b('dropdown__item', { mix, mods }, { separator })}>{children}</div>;
+}

--- a/web/app/components/dropdown/__item/dropdown__item.scss
+++ b/web/app/components/dropdown/__item/dropdown__item.scss
@@ -1,0 +1,14 @@
+.dropdown__item {
+  a, button {
+    display: block;
+    width: 100%;
+    text-align: left;
+    padding: 5px 15px;
+  }
+
+  &_separator {
+    border-bottom: 1px solid #259c9a;
+    margin-bottom: 5px;
+    padding: 5px 15px;
+  }
+}

--- a/web/app/components/dropdown/__items/dropdown__items.scss
+++ b/web/app/components/dropdown/__items/dropdown__items.scss
@@ -1,0 +1,3 @@
+.dropdown__items {
+    padding: 5px 0;
+}

--- a/web/app/components/dropdown/__title/dropdown__title.scss
+++ b/web/app/components/dropdown/__title/dropdown__title.scss
@@ -1,0 +1,12 @@
+.dropdown__title {
+  border: none;
+  background: none;
+  font-weight: bold;
+  padding: 0;
+  margin: 0;
+
+  &::after {
+    content: '\25BE';
+    margin-left: 2px;
+  }
+}

--- a/web/app/components/dropdown/_active/dropdown_active.scss
+++ b/web/app/components/dropdown/_active/dropdown_active.scss
@@ -1,0 +1,5 @@
+.dropdown_active {
+  .dropdown__content {
+    display: block;
+  }
+}

--- a/web/app/components/dropdown/dropdown.jsx
+++ b/web/app/components/dropdown/dropdown.jsx
@@ -1,0 +1,76 @@
+/** @jsx h */
+import { Component, h } from 'preact';
+
+import Button from 'components/button';
+
+export default class Dropdown extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      isActive: props.isActive || false,
+    };
+
+    this.onTitleClick = this.onTitleClick.bind(this);
+    this.onOutsideClick = this.onOutsideClick.bind(this);
+  }
+
+  onTitleClick() {
+    this.setState({
+      isActive: !this.state.isActive,
+    });
+
+    if (this.props.onTitleClick) {
+      this.props.onTitleClick();
+    }
+  }
+
+  onOutsideClick(e) {
+    if (!this.rootNode.contains(e.target)) {
+      if (this.state.isActive) {
+        this.setState({
+          isActive: false,
+        });
+      }
+    }
+  }
+
+  componentDidMount() {
+    document.addEventListener('click', this.onOutsideClick);
+
+    if (parent) {
+      parent.document.addEventListener('click', this.onOutsideClick);
+    }
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('click', this.onOutsideClick);
+
+    if (parent) {
+      parent.document.removeEventListener('click', this.onOutsideClick);
+    }
+  }
+
+  render(props, { isActive }) {
+    const { title, heading, children, mix, mods } = props;
+
+    return (
+      <div className={b('dropdown', { mix, mods }, { active: isActive })} ref={r => (this.rootNode = r)}>
+        <Button
+          aria-haspopup="listbox"
+          aria-expanded={isActive && 'true'}
+          mix="dropdown__title"
+          type="button"
+          onClick={this.onTitleClick}
+        >
+          {title}
+        </Button>
+
+        <div className="dropdown__content" tabindex="-1" role="listbox">
+          {heading && <div className="dropdown__heading">{heading}</div>}
+          <div className="dropdown__items">{children}</div>
+        </div>
+      </div>
+    );
+  }
+}

--- a/web/app/components/dropdown/dropdown.scss
+++ b/web/app/components/dropdown/dropdown.scss
@@ -1,0 +1,4 @@
+.dropdown {
+  display: inline-block;
+  position: relative;
+}

--- a/web/app/components/dropdown/index.js
+++ b/web/app/components/dropdown/index.js
@@ -1,0 +1,10 @@
+export { default } from './dropdown';
+export { default as DropdownItem } from './__item/dropdown__item';
+
+require('./dropdown.scss');
+require('./_active/dropdown_active.scss');
+
+require('./__item/dropdown__item.scss');
+require('./__items/dropdown__items.scss');
+require('./__title/dropdown__title.scss');
+require('./__content/dropdown__content.scss');

--- a/web/app/deleteme.js
+++ b/web/app/deleteme.js
@@ -1,0 +1,28 @@
+import { NODE_ID } from 'common/constants';
+import { approveDeleteMe } from 'common/api';
+import { token } from 'common/settings';
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', init);
+} else {
+  init();
+}
+
+function init() {
+  const node = document.getElementById(NODE_ID);
+
+  if (!node) {
+    console.error("Remark42: Can't find root node.");
+    return;
+  }
+  approveDeleteMe(token).then(
+    data =>
+      (node.innerHTML = `
+        <h3>User deleted successfully</h3>
+        <pre>${JSON.stringify(data, null, 4)}</pre>`),
+    err =>
+      (node.innerHTML = `
+        <h3>Something went wrong</h3>
+        <pre>${err}</pre>`)
+  );
+}

--- a/web/app/testUtils/mockStyles.js
+++ b/web/app/testUtils/mockStyles.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/web/app/utils/email.js
+++ b/web/app/utils/email.js
@@ -27,7 +27,7 @@ link: ${link}
 }
 
 export function requestDeletion() {
-  deleteMe().then(data => {
+  return deleteMe().then(data => {
     const email = store.get('config').admin_email;
     const { subject, message } = getDeleteInformationMessage(data.user_id, siteId, data.link);
     window.location = `mailto:${email}?subject=${subject}&body=${message}`;

--- a/web/app/utils/email.js
+++ b/web/app/utils/email.js
@@ -30,6 +30,6 @@ export function requestDeletion() {
   deleteMe().then(data => {
     const email = store.get('config').admin_email;
     const { subject, message } = getDeleteInformationMessage(data.user_id, siteId, data.link);
-    window.open(`mailto:${email}?subject=${subject}&body=${message}`);
+    window.location = `mailto:${email}?subject=${subject}&body=${message}`;
   });
 }

--- a/web/app/utils/email.js
+++ b/web/app/utils/email.js
@@ -1,0 +1,35 @@
+import store from '../common/store';
+import { siteId } from '../common/settings';
+import { deleteMe } from '../common/api';
+
+// The right line breaks code in the body of inline email
+// should be not just %0A, but %0D%0A
+// see: https://www.ietf.org/rfc/rfc2368.txt
+const LINE_BREAK_CODE = '%0D%0A';
+
+export function getDeleteInformationMessage(userId, siteId, link) {
+  const subject = encodeURIComponent("Request to delete user's information");
+  const message = encodeURIComponent(`Request to delete all information about ${userId} from remark42 on ${siteId}
+
+[you can provide the reason for removal request, optional]
+
+=== DO NOT REMOVE THE TEXT BELOW THIS LINE ===
+
+site: ${siteId}
+user: ${userId}
+link: ${link}
+`).replace('%0A', LINE_BREAK_CODE);
+
+  return {
+    subject,
+    message,
+  };
+}
+
+export function requestDeletion() {
+  deleteMe().then(data => {
+    const email = store.get('config').admin_email;
+    const { subject, message } = getDeleteInformationMessage(data.user_id, siteId, data.link);
+    window.open(`mailto:${email}?subject=${subject}&body=${message}`);
+  });
+}

--- a/web/app/utils/noop.js
+++ b/web/app/utils/noop.js
@@ -1,0 +1,1 @@
+export default function noop() {}

--- a/web/deleteme.html
+++ b/web/deleteme.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>remark42</title>
+  <base target="_blank">
+  <style>
+    html, body {
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+    }
+
+    .preloader {
+      width: 60px;
+      text-align: center;
+      font-size: 0;
+    }
+
+    .preloader_view_iframe {
+      margin: 0 auto;
+    }
+
+    .preloader__bounce {
+      display: inline-block;
+      width: 10px;
+      height: 10px;
+      margin-right: 3px;
+      background-color: #333;
+      border-radius: 100%;
+      animation: iframePreloaderBounce 1.4s infinite ease-in-out both;
+    }
+
+    .preloader__bounce:first-child {
+      animation-delay: -.32s;
+    }
+
+    .preloader__bounce:nth-child(2) {
+      animation-delay: -.16s;
+    }
+
+    .preloader__bounce:last-child {
+      margin-right: 0;
+    }
+
+    @keyframes iframePreloaderBounce {
+      0% {
+        transform: scale(0);
+      }
+
+      40% {
+        transform: scale(1);
+      }
+
+      80%, 100% {
+        transform: scale(0);
+      }
+    }
+  </style>
+</head>
+<body>
+  <div id="remark42">
+    <div class="preloader preloader_view_iframe">
+      <div class="preloader__bounce"></div>
+      <div class="preloader__bounce"></div>
+      <div class="preloader__bounce"></div>
+    </div>
+  </div>
+  <script src="deleteme.js"></script>
+</body>
+</html>

--- a/web/package.json
+++ b/web/package.json
@@ -83,7 +83,10 @@
     ],
     "testMatch": [
       "<rootDir>/**/*.test.js"
-    ]
+    ],
+    "moduleNameMapper": {
+      "\\.scss$": "<rootDir>/app/testUtils/mockStyles.js"
+    }
   },
   "engines": {
     "node": ">=8"

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -46,6 +46,7 @@ module.exports = {
     counter: './app/counter',
     'last-comments': './app/last-comments',
     remark: './app/remark',
+    deleteme: './app/deleteme',
   },
   output: {
     path: publicFolder,
@@ -129,7 +130,7 @@ module.exports = {
             openAnalyzer: false,
           }),
         ]),
-    new Copy(['./iframe.html']),
+    new Copy(['./iframe.html', './deleteme.html']),
   ],
   watchOptions: {
     ignored: /(node_modules|\.vendor\.js$)/,


### PR DESCRIPTION
Closes #73

* Add the API post request deleteMe
* Add a trigger button
* Add an utils/email module with the template and window opener
* Add a dropdown component
* Add a button component
* Hide the user-id text and a logout bout in the dropdown
* Add a noop empty function to pass a default handler callback to components

## Issue
https://github.com/umputun/remark/issues/73

## Description
UI should show a link (authed users only) to delete all info. The request is POST /deleteme?site_id=site and response {"site": siteID, "user_id": user.ID, "token": tokenStr, "link": link}

UI should invoke email client and fill "to" with admin email (part of GET /config response), subj with "Request to delete user's information" and email text

## Screenshot and Gif
![image](https://user-images.githubusercontent.com/4667275/41876232-73eeee7e-78cd-11e8-8c10-b37160bcc212.png)

---

![delete-me](https://user-images.githubusercontent.com/4667275/41876111-167b4148-78cd-11e8-8b0c-00343c8b75f4.gif)
