### PR TITLE
add rss feed to replies #111

### DIFF
--- a/backend/app/rest/api/rss.go
+++ b/backend/app/rest/api/rss.go
@@ -127,7 +127,7 @@ func (s *Rest) rssRepliesCtrl(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/xml; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
-	if _, err := w.Write([]byte(data)); err != nil {
+	if _, err := w.Write(data); err != nil {
 		log.Printf("[WARN] failed to send reponse to %s, %s", r.RemoteAddr, err)
 	}
 }

--- a/backend/app/rest/api/rss_test.go
+++ b/backend/app/rest/api/rss_test.go
@@ -158,6 +158,137 @@ func TestServer_RssWithReply(t *testing.T) {
 	assert.Equal(t, expected, res)
 }
 
+func TestServer_RssReplies(t *testing.T) {
+	srv, ts := prep(t)
+	assert.NotNil(t, srv)
+	defer cleanup(ts)
+
+	waitOnSecChange()
+
+	pubDate := time.Now().Format(time.RFC1123Z)
+
+	c1 := store.Comment{
+		Text:    "c1",
+		Locator: store.Locator{URL: "https://radio-t.com/blah1", SiteID: "radio-t"},
+	}
+	id1 := addComment(t, c1, ts)
+	c2 := store.Comment{
+		Text:    "c2",
+		Locator: store.Locator{URL: "https://radio-t.com/blah1", SiteID: "radio-t"},
+	}
+	id2 := addComment(t, c2, ts)
+	c3 := store.Comment{
+		Text:    "c1 : c3",
+		Locator: store.Locator{URL: "https://radio-t.com/blah1", SiteID: "radio-t"},
+	}
+	c3.ParentID = id1
+	id3 := addComment(t, c3, ts)
+	c4 := store.Comment{
+		Text:    "c1 : c4",
+		Locator: store.Locator{URL: "https://radio-t.com/blah1", SiteID: "radio-t"},
+	}
+	c4.ParentID = id1
+	id4 := addComment(t, c4, ts)
+	c5 := store.Comment{
+		Text:    "c2 : c5",
+		Locator: store.Locator{URL: "https://radio-t.com/blah1", SiteID: "radio-t"},
+	}
+	c5.ParentID = id2
+	id5 := addComment(t, c5, ts)
+	c6 := store.Comment{
+		Text:    "c1 : c3 : c6",
+		Locator: store.Locator{URL: "https://radio-t.com/blah1", SiteID: "radio-t"},
+	}
+	c6.ParentID = id3
+	id6 := addComment(t, c6, ts)
+
+	// replies for c1. Must be [c6, c4, c3]
+	res, code := get(t, ts.URL+"/api/v1/rss/reply?id="+id1+"&site=radio-t&url=https://radio-t.com/blah1")
+	assert.Equal(t, 200, code)
+	t.Log(res)
+	expected := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?><rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+	    <channel>
+	        <title>Remark42 comments</title>
+	        <link>https://radio-t.com/blah1</link>
+	        <description>comment updates</description>
+	        <pubDate>%s</pubDate>
+	        <item>
+		      <title>developer one &gt; developer one</title>
+		      <link>https://radio-t.com/blah1#remark42__comment-%s</link>
+		      <description>&lt;p&gt;c1 : c3 : c6&lt;/p&gt;&#xA;</description>
+		      <author>developer one</author>
+		      <pubDate>%s</pubDate>
+			</item>
+			<item>
+		      <title>developer one &gt; developer one</title>
+		      <link>https://radio-t.com/blah1#remark42__comment-%s</link>
+		      <description>&lt;p&gt;c1 : c4&lt;/p&gt;&#xA;</description>
+		      <author>developer one</author>
+		      <pubDate>%s</pubDate>
+			</item>
+			<item>
+		      <title>developer one &gt; developer one</title>
+		      <link>https://radio-t.com/blah1#remark42__comment-%s</link>
+		      <description>&lt;p&gt;c1 : c3&lt;/p&gt;&#xA;</description>
+		      <author>developer one</author>
+		      <pubDate>%s</pubDate>
+	        </item>
+	     </channel>
+	</rss>`, pubDate, id6, pubDate, id4, pubDate, id3, pubDate)
+	expected, res = cleanRssFormatting(expected, res)
+	assert.Equal(t, expected, res)
+
+	// replies for c2. Must be [c5]
+	res, code = get(t, ts.URL+"/api/v1/rss/reply?id="+id2+"&site=radio-t&url=https://radio-t.com/blah1")
+	assert.Equal(t, 200, code)
+	t.Log(res)
+	expected = fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?><rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+	    <channel>
+	        <title>Remark42 comments</title>
+	        <link>https://radio-t.com/blah1</link>
+	        <description>comment updates</description>
+	        <pubDate>%s</pubDate>
+	        <item>
+		      <title>developer one &gt; developer one</title>
+		      <link>https://radio-t.com/blah1#remark42__comment-%s</link>
+		      <description>&lt;p&gt;c2 : c5&lt;/p&gt;&#xA;</description>
+		      <author>developer one</author>
+		      <pubDate>%s</pubDate>
+			</item>
+	     </channel>
+	</rss>`, pubDate, id5, pubDate)
+	expected, res = cleanRssFormatting(expected, res)
+	assert.Equal(t, expected, res)
+
+	// replies for c3. Must be [c6]
+	res, code = get(t, ts.URL+"/api/v1/rss/reply?id="+id3+"&site=radio-t&url=https://radio-t.com/blah1")
+	assert.Equal(t, 200, code)
+	t.Log(res)
+	expected = fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?><rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+	    <channel>
+	        <title>Remark42 comments</title>
+	        <link>https://radio-t.com/blah1</link>
+	        <description>comment updates</description>
+	        <pubDate>%s</pubDate>
+	        <item>
+		      <title>developer one &gt; developer one</title>
+		      <link>https://radio-t.com/blah1#remark42__comment-%s</link>
+		      <description>&lt;p&gt;c1 : c3 : c6&lt;/p&gt;&#xA;</description>
+		      <author>developer one</author>
+		      <pubDate>%s</pubDate>
+			</item>
+	     </channel>
+	</rss>`, pubDate, id6, pubDate)
+	expected, res = cleanRssFormatting(expected, res)
+	assert.Equal(t, expected, res)
+
+	_, code = get(t, ts.URL+"/api/v1/rss/reply?id="+id1+"&site=radio-t-bad&url=https://radio-t.com/blah1")
+	assert.Equal(t, 400, code)
+
+	_, code = get(t, ts.URL+"/api/v1/rss/reply?id=badID&site=radio-t&url=https://radio-t.com/blah1")
+	assert.Equal(t, 400, code)
+}
+
 func waitOnSecChange() {
 	for {
 		if time.Now().Nanosecond() < 100000000 {

--- a/backend/app/store/engine/bolt_accessor.go
+++ b/backend/app/store/engine/bolt_accessor.go
@@ -166,7 +166,7 @@ func (b *BoltDB) Find(locator store.Locator, sortFld string) (comments []store.C
 		})
 	})
 
-	comments = sortComments(comments, sortFld)
+	comments = SortComments(comments, sortFld)
 	return comments, err
 }
 

--- a/backend/app/store/engine/engine.go
+++ b/backend/app/store/engine/engine.go
@@ -54,8 +54,8 @@ type Admin interface {
 	IsVerified(siteID string, userID string) bool                                // check verified status
 }
 
-// sortComments is for engines can't sort data internally
-func sortComments(comments []store.Comment, sortFld string) []store.Comment {
+// SortComments is for engines can't sort data internally
+func SortComments(comments []store.Comment, sortFld string) []store.Comment {
 	sort.Slice(comments, func(i, j int) bool {
 		switch sortFld {
 		case "+time", "-time", "time", "+active", "-active", "active":

--- a/backend/app/store/engine/engine_test.go
+++ b/backend/app/store/engine/engine_test.go
@@ -17,25 +17,25 @@ func TestEngine_sortComments(t *testing.T) {
 		{ID: "4", Score: 6, Timestamp: time.Date(2018, 2, 5, 10, 4, 0, 0, time.Local)},
 	}
 
-	sortComments(cc, "+time")
+	SortComments(cc, "+time")
 	assert.Equal(t, "1", cc[0].ID)
 	assert.Equal(t, "2", cc[1].ID)
 	assert.Equal(t, "3", cc[2].ID)
 	assert.Equal(t, "4", cc[3].ID)
 
-	sortComments(cc, "-time")
+	SortComments(cc, "-time")
 	assert.Equal(t, "4", cc[0].ID)
 	assert.Equal(t, "3", cc[1].ID)
 	assert.Equal(t, "2", cc[2].ID)
 	assert.Equal(t, "1", cc[3].ID)
 
-	sortComments(cc, "score")
+	SortComments(cc, "score")
 	assert.Equal(t, "2", cc[0].ID)
 	assert.Equal(t, "1", cc[1].ID)
 	assert.Equal(t, "3", cc[2].ID)
 	assert.Equal(t, "4", cc[3].ID)
 
-	sortComments(cc, "-score")
+	SortComments(cc, "-score")
 	assert.Equal(t, "3", cc[0].ID)
 	assert.Equal(t, "4", cc[1].ID)
 	assert.Equal(t, "1", cc[2].ID)


### PR DESCRIPTION
This feature adds /rss/reply endpoint that generates RSS feed with replies for the comment. 
Replies are sorted by time from last to first. Amount of replies is limited up to maxRssItems (20).
For sorting purpose sortComments function from engine package had to do public, so I'm not sure that it is a good solution
@umputun I'm will be glad any feedback