### PR TITLE
Fix right margin for verified user icon

### DIFF
--- a/web/app/components/comment/__time/comment__time.scss
+++ b/web/app/components/comment/__time/comment__time.scss
@@ -1,4 +1,5 @@
 .comment__time {
+  margin-left: 8px;
   margin-right: 8px;
   vertical-align: middle;
   color: #999;

--- a/web/app/components/comment/__username/comment__username.scss
+++ b/web/app/components/comment/__username/comment__username.scss
@@ -1,5 +1,4 @@
 .comment__username {
-  margin-right: 8px;
   vertical-align: middle;
   font-weight: 700;
   text-decoration: none;


### PR DESCRIPTION
Fix for the #134 
<img width="380" alt="screen shot 2018-07-07 at 12 08 06" src="https://user-images.githubusercontent.com/842700/42409140-81927400-81de-11e8-82f4-5e39c35e3625.png">
