### PR TITLE
RSS replies to a user #111

### DIFF
--- a/backend/app/rest/api/rss.go
+++ b/backend/app/rest/api/rss.go
@@ -23,6 +23,7 @@ func (s *Rest) rssRoutes() chi.Router {
 	router := chi.NewRouter()
 	router.Get("/post", s.rssPostCommentsCtrl)
 	router.Get("/site", s.rssSiteCommentsCtrl)
+	router.Get("/reply", s.rssRepliesCtrl)
 	return router
 }
 
@@ -78,6 +79,54 @@ func (s *Rest) rssSiteCommentsCtrl(w http.ResponseWriter, r *http.Request) {
 
 	if err != nil {
 		rest.SendErrorJSON(w, r, http.StatusBadRequest, err, "can't get last comments")
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/xml; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write(data); err != nil {
+		log.Printf("[WARN] failed to send response to %s, %s", r.RemoteAddr, err)
+	}
+}
+
+// GET /rss/reply?user=userID&site=siteID
+func (s *Rest) rssRepliesCtrl(w http.ResponseWriter, r *http.Request) {
+	userID := r.URL.Query().Get("user")
+	siteID := r.URL.Query().Get("site")
+	log.Printf("[DEBUG] get rss replies to user %s for site %s", userID, siteID)
+
+	data, err := s.Cache.Get(cache.Key(cache.URLKey(r), siteID, userID), func() ([]byte, error) {
+		comments, e := s.DataService.Last(siteID, 100)
+		if e != nil {
+			return nil, e
+		}
+		comments = s.adminService.alterComments(comments, r)
+
+		replies := []store.Comment{}
+		for _, c := range comments {
+			if len(replies) > maxRssItems || c.Timestamp.Add(30*time.Minute).Before(time.Now()) {
+				break
+			}
+			if c.ParentID != "" && !c.Deleted && c.User.ID != userID { // not interested replies to yourself
+				pc, e := s.DataService.Get(c.Locator, c.ParentID)
+				if e != nil {
+					return nil, e
+				}
+				if pc.User.ID == userID {
+					replies = append(replies, c)
+				}
+			}
+		}
+
+		rss, e := s.toRssFeed(siteID, replies)
+		if e != nil {
+			return nil, e
+		}
+		return []byte(rss), e
+	})
+
+	if err != nil {
+		rest.SendErrorJSON(w, r, http.StatusBadRequest, err, "can't get replies")
 		return
 	}
 


### PR DESCRIPTION
Added `/rss/reply?user=userID&site=siteID` endpoint. It retrieves last 100 comments for site `siteID` and for each comment reads parent to determine is it reply to `userID` or not. Stops iterate when max replies are found or comment were published later than 30 minutes. Skips replies when user replies to himself.
relates to #111 