### PR TITLE
Close DataStore on cleanup in tests

### DIFF
--- a/backend/app/rest/api/admin_test.go
+++ b/backend/app/rest/api/admin_test.go
@@ -20,7 +20,7 @@ import (
 func TestAdmin_Delete(t *testing.T) {
 	srv, ts := prep(t)
 	assert.NotNil(t, srv)
-	defer cleanup(ts)
+	defer cleanup(ts, srv)
 
 	c1 := store.Comment{Text: "test test #1", User: store.User{ID: "id", Name: "name"},
 		Locator: store.Locator{SiteID: "radio-t", URL: "https://radio-t.com/blah"}}
@@ -51,7 +51,7 @@ func TestAdmin_Delete(t *testing.T) {
 func TestAdmin_DeleteUser(t *testing.T) {
 	srv, ts := prep(t)
 	assert.NotNil(t, srv)
-	defer cleanup(ts)
+	defer cleanup(ts, srv)
 
 	c1 := store.Comment{Text: "test test #1", Orig: "o test test #1", User: store.User{ID: "id1", Name: "name"},
 		Locator: store.Locator{SiteID: "radio-t", URL: "https://radio-t.com/blah"}}
@@ -105,7 +105,7 @@ func TestAdmin_DeleteUser(t *testing.T) {
 func TestAdmin_Pin(t *testing.T) {
 	srv, ts := prep(t)
 	assert.NotNil(t, srv)
-	defer cleanup(ts)
+	defer cleanup(ts, srv)
 
 	c1 := store.Comment{Text: "test test #1",
 		Locator: store.Locator{SiteID: "radio-t", URL: "https://radio-t.com/blah"}}
@@ -149,7 +149,7 @@ func TestAdmin_Pin(t *testing.T) {
 func TestAdmin_Block(t *testing.T) {
 	srv, ts := prep(t)
 	assert.NotNil(t, srv)
-	defer cleanup(ts)
+	defer cleanup(ts, srv)
 
 	c1 := store.Comment{Text: "test test #1", Locator: store.Locator{SiteID: "radio-t",
 		URL: "https://radio-t.com/blah"}, User: store.User{Name: "user1 name", ID: "user1"}}
@@ -230,7 +230,7 @@ func TestAdmin_Block(t *testing.T) {
 func TestAdmin_BlockedList(t *testing.T) {
 	srv, ts := prep(t)
 	assert.NotNil(t, srv)
-	defer cleanup(ts)
+	defer cleanup(ts, srv)
 
 	client := http.Client{}
 
@@ -272,7 +272,7 @@ func TestAdmin_BlockedList(t *testing.T) {
 func TestAdmin_ReadOnly(t *testing.T) {
 	srv, ts := prep(t)
 	assert.NotNil(t, srv)
-	defer cleanup(ts)
+	defer cleanup(ts, srv)
 
 	c1 := store.Comment{Text: "test test #1", Locator: store.Locator{SiteID: "radio-t",
 		URL: "https://radio-t.com/blah"}, User: store.User{Name: "user1 name", ID: "user1"}}
@@ -318,7 +318,7 @@ func TestAdmin_ReadOnly(t *testing.T) {
 func TestAdmin_ReadOnlyWithAge(t *testing.T) {
 	srv, ts := prep(t)
 	assert.NotNil(t, srv)
-	defer cleanup(ts)
+	defer cleanup(ts, srv)
 
 	c1 := store.Comment{Text: "test test #1", Locator: store.Locator{SiteID: "radio-t",
 		URL: "https://radio-t.com/blah"}, User: store.User{Name: "user1 name", ID: "user1"},
@@ -360,7 +360,7 @@ func TestAdmin_ReadOnlyWithAge(t *testing.T) {
 func TestAdmin_Verify(t *testing.T) {
 	srv, ts := prep(t)
 	assert.NotNil(t, srv)
-	defer cleanup(ts)
+	defer cleanup(ts, srv)
 
 	c1 := store.Comment{Text: "test test #1", Locator: store.Locator{SiteID: "radio-t",
 		URL: "https://radio-t.com/blah"}, User: store.User{Name: "user1 name", ID: "user1"}}
@@ -417,7 +417,7 @@ func TestAdmin_Verify(t *testing.T) {
 func TestAdmin_ExportStream(t *testing.T) {
 	srv, ts := prep(t)
 	assert.NotNil(t, srv)
-	defer cleanup(ts)
+	defer cleanup(ts, srv)
 
 	c1 := store.Comment{Text: "test test #1",
 		Locator: store.Locator{SiteID: "radio-t", URL: "https://radio-t.com/blah1"}}
@@ -437,7 +437,7 @@ func TestAdmin_ExportStream(t *testing.T) {
 func TestAdmin_ExportFile(t *testing.T) {
 	srv, ts := prep(t)
 	assert.NotNil(t, srv)
-	defer cleanup(ts)
+	defer cleanup(ts, srv)
 
 	c1 := store.Comment{Text: "test test #1",
 		Locator: store.Locator{SiteID: "radio-t", URL: "https://radio-t.com/blah1"}}
@@ -469,7 +469,7 @@ func TestAdmin_ExportFile(t *testing.T) {
 func TestAdmin_DeleteMeRequest(t *testing.T) {
 	srv, ts := prep(t)
 	assert.NotNil(t, srv)
-	defer cleanup(ts)
+	defer cleanup(ts, srv)
 
 	c1 := store.Comment{Text: "test test #1", Locator: store.Locator{SiteID: "radio-t",
 		URL: "https://radio-t.com/blah"}, User: store.User{Name: "user1 name", ID: "user1"}}
@@ -517,7 +517,7 @@ func TestAdmin_DeleteMeRequest(t *testing.T) {
 func TestAdmin_DeleteMeRequestFailed(t *testing.T) {
 	srv, ts := prep(t)
 	assert.NotNil(t, srv)
-	defer cleanup(ts)
+	defer cleanup(ts, srv)
 
 	c1 := store.Comment{Text: "test test #1", Locator: store.Locator{SiteID: "radio-t",
 		URL: "https://radio-t.com/blah"}, User: store.User{Name: "user1 name", ID: "user1"}}
@@ -578,7 +578,7 @@ func TestAdmin_DeleteMeRequestFailed(t *testing.T) {
 func TestAdmin_GetUserInfo(t *testing.T) {
 	srv, ts := prep(t)
 	assert.NotNil(t, srv)
-	defer cleanup(ts)
+	defer cleanup(ts, srv)
 
 	c1 := store.Comment{Text: "test test #1", Locator: store.Locator{SiteID: "radio-t",
 		URL: "https://radio-t.com/blah"}, User: store.User{Name: "user1 name", ID: "user1"}}

--- a/backend/app/rest/api/rest_private_test.go
+++ b/backend/app/rest/api/rest_private_test.go
@@ -19,7 +19,7 @@ import (
 func TestRest_Create(t *testing.T) {
 	srv, ts := prep(t)
 	require.NotNil(t, srv)
-	defer cleanup(ts)
+	defer cleanup(ts, srv)
 
 	resp, err := post(t, ts.URL+"/api/v1/comment",
 		`{"text": "test 123", "locator":{"url": "https://radio-t.com/blah1", "site": "radio-t"}}`)
@@ -40,7 +40,7 @@ func TestRest_Create(t *testing.T) {
 func TestRest_CreateOldPost(t *testing.T) {
 	srv, ts := prep(t)
 	require.NotNil(t, srv)
-	defer cleanup(ts)
+	defer cleanup(ts, srv)
 
 	// make old, but not too old comment
 	old := store.Comment{Text: "test test old", ParentID: "", Timestamp: time.Now().AddDate(0, 0, -5),
@@ -74,7 +74,7 @@ func TestRest_CreateOldPost(t *testing.T) {
 func TestRest_CreateTooBig(t *testing.T) {
 	srv, ts := prep(t)
 	require.NotNil(t, srv)
-	defer cleanup(ts)
+	defer cleanup(ts, srv)
 
 	longComment := fmt.Sprintf(`{"text": "%4001s", "locator":{"url": "https://radio-t.com/blah1", "site": "radio-t"}}`, "Щ")
 
@@ -106,7 +106,7 @@ func TestRest_CreateRejected(t *testing.T) {
 
 	srv, ts := prep(t)
 	require.NotNil(t, srv)
-	defer cleanup(ts)
+	defer cleanup(ts, srv)
 	body := `{"text": "test 123", "locator":{"url": "https://radio-t.com/blah1", "site": "radio-t"}}`
 
 	// try to create without auth
@@ -117,7 +117,7 @@ func TestRest_CreateRejected(t *testing.T) {
 func TestRest_CreateAndGet(t *testing.T) {
 	srv, ts := prep(t)
 	assert.NotNil(t, srv)
-	defer cleanup(ts)
+	defer cleanup(ts, srv)
 
 	// create comment
 	resp, err := post(t, ts.URL+"/api/v1/comment",
@@ -149,7 +149,7 @@ func TestRest_CreateAndGet(t *testing.T) {
 func TestRest_Update(t *testing.T) {
 	srv, ts := prep(t)
 	assert.NotNil(t, srv)
-	defer cleanup(ts)
+	defer cleanup(ts, srv)
 
 	c1 := store.Comment{Text: "test test #1", ParentID: "p1",
 		Locator: store.Locator{SiteID: "radio-t", URL: "https://radio-t.com/blah1"}}
@@ -188,7 +188,7 @@ func TestRest_Update(t *testing.T) {
 func TestRest_UpdateNotOwner(t *testing.T) {
 	srv, ts := prep(t)
 	assert.NotNil(t, srv)
-	defer cleanup(ts)
+	defer cleanup(ts, srv)
 
 	c1 := store.Comment{Text: "test test #1", ParentID: "p1",
 		Locator: store.Locator{SiteID: "radio-t", URL: "https://radio-t.com/blah1"}, User: store.User{ID: "xyz"}}
@@ -220,7 +220,7 @@ func TestRest_UpdateNotOwner(t *testing.T) {
 func TestRest_Vote(t *testing.T) {
 	srv, ts := prep(t)
 	assert.NotNil(t, srv)
-	defer cleanup(ts)
+	defer cleanup(ts, srv)
 
 	c1 := store.Comment{Text: "test test #1",
 		Locator: store.Locator{SiteID: "radio-t", URL: "https://radio-t.com/blah"}}
@@ -264,7 +264,7 @@ func TestRest_Vote(t *testing.T) {
 func TestRest_UserAllData(t *testing.T) {
 	srv, ts := prep(t)
 	assert.NotNil(t, srv)
-	defer cleanup(ts)
+	defer cleanup(ts, srv)
 
 	// write 3 comments
 	user := store.User{ID: "dev", Name: "user name 1"}
@@ -319,7 +319,7 @@ func TestRest_UserAllData(t *testing.T) {
 func TestRest_UserAllDataManyComments(t *testing.T) {
 	srv, ts := prep(t)
 	assert.NotNil(t, srv)
-	defer cleanup(ts)
+	defer cleanup(ts, srv)
 
 	user := store.User{ID: "dev", Name: "user name 1"}
 	c := store.Comment{User: user, Text: "test test #1", Locator: store.Locator{SiteID: "radio-t",
@@ -353,7 +353,7 @@ func TestRest_UserAllDataManyComments(t *testing.T) {
 func TestRest_DeleteMe(t *testing.T) {
 	srv, ts := prep(t)
 	assert.NotNil(t, srv)
-	defer cleanup(ts)
+	defer cleanup(ts, srv)
 
 	client := http.Client{}
 	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/api/v1/deleteme?site=radio-t", ts.URL), nil)

--- a/backend/app/rest/api/rest_public_test.go
+++ b/backend/app/rest/api/rest_public_test.go
@@ -19,7 +19,7 @@ import (
 func TestRest_Ping(t *testing.T) {
 	srv, ts := prep(t)
 	require.NotNil(t, srv)
-	defer cleanup(ts)
+	defer cleanup(ts, srv)
 
 	res, code := get(t, ts.URL+"/api/v1/ping")
 	assert.Equal(t, "pong", res)
@@ -29,7 +29,7 @@ func TestRest_Ping(t *testing.T) {
 func TestRest_Preview(t *testing.T) {
 	srv, ts := prep(t)
 	require.NotNil(t, srv)
-	defer cleanup(ts)
+	defer cleanup(ts, srv)
 
 	resp, err := post(t, ts.URL+"/api/v1/preview", `{"text": "test 123", "locator":{"url": "https://radio-t.com/blah1", "site": "radio-t"}}`)
 	assert.Nil(t, err)
@@ -42,7 +42,7 @@ func TestRest_Preview(t *testing.T) {
 func TestRest_PreviewWithMD(t *testing.T) {
 	srv, ts := prep(t)
 	require.NotNil(t, srv)
-	defer cleanup(ts)
+	defer cleanup(ts, srv)
 
 	text := `
 # h1
@@ -70,7 +70,7 @@ BKT
 func TestRest_Find(t *testing.T) {
 	srv, ts := prep(t)
 	assert.NotNil(t, srv)
-	defer cleanup(ts)
+	defer cleanup(ts, srv)
 
 	_, code := get(t, ts.URL+"/api/v1/find?site=radio-t&url=https://radio-t.com/blah1")
 	assert.Equal(t, 400, code, "nothing in")
@@ -124,7 +124,7 @@ func TestRest_Find(t *testing.T) {
 func TestRest_FindAge(t *testing.T) {
 	srv, ts := prep(t)
 	assert.NotNil(t, srv)
-	defer cleanup(ts)
+	defer cleanup(ts, srv)
 
 	c1 := store.Comment{Text: "test test #1", ParentID: "", Timestamp: time.Now().AddDate(0, 0, -5),
 		Locator: store.Locator{SiteID: "radio-t", URL: "https://radio-t.com/blah1"}, User: store.User{ID: "u1"}}
@@ -156,7 +156,7 @@ func TestRest_FindAge(t *testing.T) {
 func TestRest_FindReadOnly(t *testing.T) {
 	srv, ts := prep(t)
 	assert.NotNil(t, srv)
-	defer cleanup(ts)
+	defer cleanup(ts, srv)
 
 	c1 := store.Comment{Text: "test test #1", ParentID: "", Timestamp: time.Now().AddDate(0, 0, -1),
 		Locator: store.Locator{SiteID: "radio-t", URL: "https://radio-t.com/blah1"}, User: store.User{ID: "u1"}}
@@ -198,7 +198,7 @@ func TestRest_FindReadOnly(t *testing.T) {
 func TestRest_Last(t *testing.T) {
 	srv, ts := prep(t)
 	assert.NotNil(t, srv)
-	defer cleanup(ts)
+	defer cleanup(ts, srv)
 
 	c1 := store.Comment{Text: "test test #1", ParentID: "p1",
 		Locator: store.Locator{SiteID: "radio-t", URL: "https://radio-t.com/blah1"}}
@@ -243,7 +243,7 @@ func TestRest_Last(t *testing.T) {
 func TestRest_FindUserComments(t *testing.T) {
 	srv, ts := prep(t)
 	assert.NotNil(t, srv)
-	defer cleanup(ts)
+	defer cleanup(ts, srv)
 
 	c1 := store.Comment{Text: "test test #1",
 		Locator: store.Locator{SiteID: "radio-t", URL: "https://radio-t.com/blah1"}}
@@ -280,7 +280,7 @@ func TestRest_FindUserComments(t *testing.T) {
 func TestRest_UserInfo(t *testing.T) {
 	srv, ts := prep(t)
 	assert.NotNil(t, srv)
-	defer cleanup(ts)
+	defer cleanup(ts, srv)
 
 	body, code := getWithAuth(t, ts.URL+"/api/v1/user?site=radio-t")
 	assert.Equal(t, 200, code)
@@ -294,7 +294,7 @@ func TestRest_UserInfo(t *testing.T) {
 func TestRest_Count(t *testing.T) {
 	srv, ts := prep(t)
 	assert.NotNil(t, srv)
-	defer cleanup(ts)
+	defer cleanup(ts, srv)
 
 	c1 := store.Comment{Text: "test test #1",
 		Locator: store.Locator{SiteID: "radio-t", URL: "https://radio-t.com/blah1"}}
@@ -324,7 +324,7 @@ func TestRest_Count(t *testing.T) {
 func TestRest_Counts(t *testing.T) {
 	srv, ts := prep(t)
 	assert.NotNil(t, srv)
-	defer cleanup(ts)
+	defer cleanup(ts, srv)
 
 	c1 := store.Comment{Text: "test test #1",
 		Locator: store.Locator{SiteID: "radio-t", URL: "https://radio-t.com/blah1"}}
@@ -354,7 +354,7 @@ func TestRest_Counts(t *testing.T) {
 func TestRest_List(t *testing.T) {
 	srv, ts := prep(t)
 	assert.NotNil(t, srv)
-	defer cleanup(ts)
+	defer cleanup(ts, srv)
 
 	c1 := store.Comment{Text: "test test #1",
 		Locator: store.Locator{SiteID: "radio-t", URL: "https://radio-t.com/blah1"}}
@@ -381,7 +381,7 @@ func TestRest_List(t *testing.T) {
 func TestRest_Config(t *testing.T) {
 	srv, ts := prep(t)
 	assert.NotNil(t, srv)
-	defer cleanup(ts)
+	defer cleanup(ts, srv)
 
 	body, code := get(t, ts.URL+"/api/v1/config?site=radio-t")
 	assert.Equal(t, 200, code)
@@ -401,7 +401,7 @@ func TestRest_Config(t *testing.T) {
 func TestRest_Info(t *testing.T) {
 	srv, ts := prep(t)
 	assert.NotNil(t, srv)
-	defer cleanup(ts)
+	defer cleanup(ts, srv)
 
 	srv.ReadOnlyAge = 10000000 // make sure we don't hit read-only
 
@@ -439,7 +439,7 @@ func TestRest_Info(t *testing.T) {
 func TestRest_Robots(t *testing.T) {
 	srv, ts := prep(t)
 	assert.NotNil(t, srv)
-	defer cleanup(ts)
+	defer cleanup(ts, srv)
 
 	body, code := get(t, ts.URL+"/robots.txt")
 	assert.Equal(t, 200, code)

--- a/backend/app/rest/api/rest_test.go
+++ b/backend/app/rest/api/rest_test.go
@@ -31,7 +31,7 @@ var getStartedHTML = "/tmp/getstarted.html"
 func TestRest_FileServer(t *testing.T) {
 	srv, ts := prep(t)
 	assert.NotNil(t, srv)
-	defer cleanup(ts)
+	defer cleanup(ts, srv)
 
 	body, code := get(t, ts.URL+"/web/test-remark.html")
 	assert.Equal(t, 200, code)
@@ -41,7 +41,7 @@ func TestRest_FileServer(t *testing.T) {
 func TestRest_GetStarted(t *testing.T) {
 	srv, ts := prep(t)
 	assert.NotNil(t, srv)
-	defer cleanup(ts)
+	defer cleanup(ts, srv)
 
 	err := ioutil.WriteFile(getStartedHTML, []byte("some html blah"), 0700)
 	assert.Nil(t, err)
@@ -157,8 +157,9 @@ func addComment(t *testing.T, c store.Comment, ts *httptest.Server) string {
 	return crResp["id"].(string)
 }
 
-func cleanup(ts *httptest.Server) {
+func cleanup(ts *httptest.Server, srv *Rest) {
 	ts.Close()
+	srv.DataService.Close()
 	os.Remove(testDb)
 	os.Remove(testHTML)
 }

--- a/backend/app/rest/api/rss_test.go
+++ b/backend/app/rest/api/rss_test.go
@@ -14,7 +14,7 @@ import (
 func TestServer_RssPost(t *testing.T) {
 	srv, ts := prep(t)
 	assert.NotNil(t, srv)
-	defer cleanup(ts)
+	defer cleanup(ts, srv)
 
 	waitOnSecChange()
 
@@ -55,7 +55,7 @@ func TestServer_RssPost(t *testing.T) {
 func TestServer_RssSite(t *testing.T) {
 	srv, ts := prep(t)
 	assert.NotNil(t, srv)
-	defer cleanup(ts)
+	defer cleanup(ts, srv)
 
 	waitOnSecChange()
 
@@ -109,7 +109,7 @@ func TestServer_RssSite(t *testing.T) {
 func TestServer_RssWithReply(t *testing.T) {
 	srv, ts := prep(t)
 	assert.NotNil(t, srv)
-	defer cleanup(ts)
+	defer cleanup(ts, srv)
 
 	waitOnSecChange()
 
@@ -161,7 +161,7 @@ func TestServer_RssWithReply(t *testing.T) {
 func TestServer_RssReplies(t *testing.T) {
 	srv, ts := prep(t)
 	assert.NotNil(t, srv)
-	defer cleanup(ts)
+	defer cleanup(ts, srv)
 
 	waitOnSecChange()
 


### PR DESCRIPTION
Windows fs can't remove testDb until file still used.
Therefore we need to close datastore on cleanup.