### PR TITLE
Use comment formatter for wp importer

### DIFF
--- a/backend/app/migrator/disqus.go
+++ b/backend/app/migrator/disqus.go
@@ -133,7 +133,7 @@ func (d *Disqus) convert(r io.Reader, siteID string) (ch chan store.Comment) {
 							Name: comment.AuthorName,
 							IP:   comment.IP,
 						},
-						Text:      cleanText(comment.Message),
+						Text:      d.cleanText(comment.Message),
 						Timestamp: comment.CreatedAt,
 						ParentID:  comment.Pid.Val,
 					}
@@ -158,7 +158,7 @@ func (d *Disqus) convert(r io.Reader, siteID string) (ch chan store.Comment) {
 	return commentsCh
 }
 
-func cleanText(text string) string {
+func (*Disqus) cleanText(text string) string {
 	text = strings.Replace(text, "\n", "", -1)
 	text = strings.Replace(text, "\t", "", -1)
 	return text

--- a/backend/app/migrator/wordpress.go
+++ b/backend/app/migrator/wordpress.go
@@ -100,7 +100,7 @@ func (w *WordPress) convert(r io.Reader, siteID string) chan store.Comment {
 	}{}
 
 	commentConverter := new(wpCommentConverter)
-	commentFormater := store.NewCommentFormater(commentConverter)
+	commentFormatter := store.NewCommentFormatter(commentConverter)
 
 	go func() {
 		for {
@@ -142,7 +142,7 @@ func (w *WordPress) convert(r io.Reader, siteID string) chan store.Comment {
 								Timestamp: comment.Date.time,
 								ParentID:  comment.PID,
 							}
-							commentsCh <- commentFormater.Format(c)
+							commentsCh <- commentFormatter.Format(c)
 							stats.inpComments++
 							if stats.inpComments%1000 == 0 {
 								log.Printf("[DEBUG] proccessed %d comments", stats.inpComments)

--- a/backend/app/migrator/wordpress.go
+++ b/backend/app/migrator/wordpress.go
@@ -130,8 +130,6 @@ func (w *WordPress) convert(r io.Reader, siteID string) chan store.Comment {
 								comment.PID = ""
 							}
 
-							log.Println("ParsedS")
-							log.Println(comment.Content)
 							c := store.Comment{
 								ID:      comment.ID,
 								Locator: store.Locator{URL: item.Link, SiteID: siteID},


### PR DESCRIPTION
for #156 
WP importer starts to use CommentFormatter to convert content in common way as remark does when saves comments.
Fix previous PR #188 (I did git rebase master && git push --force but nothing happen in PR)