### PR TITLE
UserInfo close by Esc fix, issue #187 

### DIFF
--- a/web/app/components/user-info/user-info.jsx
+++ b/web/app/components/user-info/user-info.jsx
@@ -24,6 +24,20 @@ class UserInfo extends Component {
       .getUserComments({ user: id, limit: 10 })
       .then(({ comments = [] }) => this.setState({ comments }))
       .finally(() => this.setState({ isLoading: false }));
+
+    document.addEventListener('keydown', this.globalOnKeyDown);
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('keydown', this.globalOnKeyDown);
+  }
+
+  globalOnKeyDown(e) {
+    // ESCAPE key pressed
+    if (e.keyCode == 27) {
+      const data = JSON.stringify({ isUserInfoShown: false });
+      window.parent.postMessage(data, '*');
+    }
   }
 
   render(props, { comments, isLoading }) {

--- a/web/app/embed.js
+++ b/web/app/embed.js
@@ -151,9 +151,6 @@ function init() {
         horizontalscrolling="no"
       />`;
       this.iframe = this.node.querySelector('iframe');
-      this.iframe.onload = () => {
-        this.iframe.contentDocument.addEventListener('keydown', this.onKeyDown);
-      };
       this.node.appendChild(this.closeEl);
       document.body.appendChild(this.style);
       document.body.appendChild(this.back);


### PR DESCRIPTION
What is going on here? To make close by Esc reliable we also need to add a `keydown` event listener to the iframe, because events do not propagate out of an iframe to a parent. Originally adding `keydown` event listener was done via a `contentDocument` property of the iframe, but the browser does not allow to access `contentDocument` if the origin of the iframe is different from the parent. Now I change it so that UserInfo component used `window.parent.postMessage` to send a message when escape is pressed. This should work reliably.