### PR TITLE
third party cookies blocked fallback

### DIFF
--- a/web/app/common/constants.js
+++ b/web/app/common/constants.js
@@ -59,7 +59,7 @@ export const STORAGE_AVAILABLE = (() => {
  */
 export const IS_THIRD_PARTY = (() => {
   try {
-    return window.parent.document.location.host !== window.location.host;
+    return window.parent.location.host !== window.location.host;
   } catch (e) {
     return true;
   }

--- a/web/app/common/constants.js
+++ b/web/app/common/constants.js
@@ -38,3 +38,29 @@ export const BLOCKING_DURATIONS = [
     value: `${60 * 24}m`,
   },
 ];
+
+/**
+ * Defines if browser storage features (cookies, localsrotage)
+ * are available or blocked via browser preferences
+ */
+export const STORAGE_AVAILABLE = (() => {
+  try {
+    localStorage.setItem('localstorage_availability_test', null);
+    localStorage.removeItem('localstorage_availability_test');
+  } catch (e) {
+    return false;
+  }
+  return true;
+})();
+
+/**
+ * Defines whether iframe loaded in cross origin environment
+ * Usefull for checking if some privacy restriction may be applied
+ */
+export const IS_THIRD_PARTY = (() => {
+  try {
+    return window.parent.document.location.host !== window.location.host;
+  } catch (e) {
+    return true;
+  }
+})();

--- a/web/app/common/constants.js
+++ b/web/app/common/constants.js
@@ -43,7 +43,7 @@ export const BLOCKING_DURATIONS = [
  * Defines if browser storage features (cookies, localsrotage)
  * are available or blocked via browser preferences
  */
-export const STORAGE_AVAILABLE = (() => {
+export const IS_STORAGE_AVAILABLE = (() => {
   try {
     localStorage.setItem('localstorage_availability_test', null);
     localStorage.removeItem('localstorage_availability_test');

--- a/web/app/common/localStorage.js
+++ b/web/app/common/localStorage.js
@@ -1,12 +1,4 @@
-export const isAvailable = (() => {
-  try {
-    localStorage.setItem('localstorage_availability_test', null);
-    localStorage.removeItem('localstorage_availability_test');
-  } catch (e) {
-    return false;
-  }
-  return true;
-})();
+import { isAvailable } from 'common/constants';
 
 const failMessage = 'remark42: localStorage access denied, check browser preferences';
 

--- a/web/app/common/localStorage.js
+++ b/web/app/common/localStorage.js
@@ -1,21 +1,21 @@
-import { isAvailable } from 'common/constants';
+import { IS_STORAGE_AVAILABLE } from 'common/constants';
 
 const failMessage = 'remark42: localStorage access denied, check browser preferences';
 
-export const setItem = isAvailable
+export const setItem = IS_STORAGE_AVAILABLE
   ? localStorage.setItem.bind(localStorage)
   : () => {
       console.error(failMessage); // eslint-disable-line no-console
     };
 
-export const getItem = isAvailable
+export const getItem = IS_STORAGE_AVAILABLE
   ? localStorage.getItem.bind(localStorage)
   : () => {
       console.error(failMessage); // eslint-disable-line no-console
       return null;
     };
 
-export const removeItem = isAvailable
+export const removeItem = IS_STORAGE_AVAILABLE
   ? localStorage.removeItem.bind(localStorage)
   : () => {
       console.error(failMessage); // eslint-disable-line no-console

--- a/web/app/common/localStorage.js
+++ b/web/app/common/localStorage.js
@@ -1,0 +1,30 @@
+export const isAvailable = (() => {
+  try {
+    localStorage.setItem('localstorage_availability_test', null);
+    localStorage.removeItem('localstorage_availability_test');
+  } catch (e) {
+    return false;
+  }
+  return true;
+})();
+
+const failMessage = 'remark42: localStorage access denied, check browser preferences';
+
+export const setItem = isAvailable
+  ? localStorage.setItem.bind(localStorage)
+  : () => {
+      console.error(failMessage); // eslint-disable-line no-console
+    };
+
+export const getItem = isAvailable
+  ? localStorage.getItem.bind(localStorage)
+  : () => {
+      console.error(failMessage); // eslint-disable-line no-console
+      return null;
+    };
+
+export const removeItem = isAvailable
+  ? localStorage.removeItem.bind(localStorage)
+  : () => {
+      console.error(failMessage); // eslint-disable-line no-console
+    };

--- a/web/app/components/auth-panel/auth-panel.jsx
+++ b/web/app/components/auth-panel/auth-panel.jsx
@@ -4,7 +4,7 @@ import { h, Component } from 'preact';
 import UserId from './__user-id/auth-panel__user-id';
 import Dropdown, { DropdownItem } from 'components/dropdown';
 import Button from 'components/button';
-import { PROVIDER_NAMES } from 'common/constants';
+import { PROVIDER_NAMES, STORAGE_AVAILABLE, IS_THIRD_PARTY } from 'common/constants';
 import { requestDeletion } from 'utils/email';
 import { getHandleClickProps } from 'common/accessibility';
 
@@ -76,28 +76,46 @@ export default class AuthPanel extends Component {
           </div>
         )}
 
-        {!loggedIn && (
-          <div className="auth-panel__column">
-            Sign in to comment using{' '}
-            {providers.map((provider, i) => {
-              const comma = i === 0 ? '' : i === providers.length - 1 ? ' or ' : ', ';
+        {STORAGE_AVAILABLE &&
+          !loggedIn && (
+            <div className="auth-panel__column">
+              Sign in to comment using{' '}
+              {providers.map((provider, i) => {
+                const comma = i === 0 ? '' : i === providers.length - 1 ? ' or ' : ', ';
 
-              return (
-                <span>
-                  {comma}
-                  <span
-                    className="auth-panel__pseudo-link"
-                    {...getHandleClickProps(() => props.onSignIn(provider))}
-                    role="link"
-                  >
-                    {PROVIDER_NAMES[provider]}
+                return (
+                  <span>
+                    {comma}
+                    <span
+                      className="auth-panel__pseudo-link"
+                      {...getHandleClickProps(() => props.onSignIn(provider))}
+                      role="link"
+                    >
+                      {PROVIDER_NAMES[provider]}
+                    </span>
                   </span>
-                </span>
-              );
-            })}
-            {'.'}
-          </div>
-        )}
+                );
+              })}
+              {'.'}
+            </div>
+          )}
+
+        {!STORAGE_AVAILABLE &&
+          IS_THIRD_PARTY && (
+            <div className="auth-panel__column">
+              Disable third-party cookies blocking to sign in or open comments in{' '}
+              <a
+                class="auth-panel__pseudo-link"
+                href={`${window.location.origin}/web/comments.html${window.location.search}`}
+                target="_blank"
+              >
+                new page
+              </a>
+            </div>
+          )}
+
+        {!STORAGE_AVAILABLE &&
+          !IS_THIRD_PARTY && <div className="auth-panel__column">Allow cookies to sign in and comment</div>}
 
         <div className="auth-panel__column">
           {user.admin && (

--- a/web/app/components/auth-panel/auth-panel.jsx
+++ b/web/app/components/auth-panel/auth-panel.jsx
@@ -4,7 +4,7 @@ import { h, Component } from 'preact';
 import UserId from './__user-id/auth-panel__user-id';
 import Dropdown, { DropdownItem } from 'components/dropdown';
 import Button from 'components/button';
-import { PROVIDER_NAMES, STORAGE_AVAILABLE, IS_THIRD_PARTY } from 'common/constants';
+import { PROVIDER_NAMES, IS_STORAGE_AVAILABLE, IS_THIRD_PARTY } from 'common/constants';
 import { requestDeletion } from 'utils/email';
 import { getHandleClickProps } from 'common/accessibility';
 
@@ -76,7 +76,7 @@ export default class AuthPanel extends Component {
           </div>
         )}
 
-        {STORAGE_AVAILABLE &&
+        {IS_STORAGE_AVAILABLE &&
           !loggedIn && (
             <div className="auth-panel__column">
               Sign in to comment using{' '}
@@ -100,7 +100,7 @@ export default class AuthPanel extends Component {
             </div>
           )}
 
-        {!STORAGE_AVAILABLE &&
+        {!IS_STORAGE_AVAILABLE &&
           IS_THIRD_PARTY && (
             <div className="auth-panel__column">
               Disable third-party cookies blocking to sign in or open comments in{' '}
@@ -114,7 +114,7 @@ export default class AuthPanel extends Component {
             </div>
           )}
 
-        {!STORAGE_AVAILABLE &&
+        {!IS_STORAGE_AVAILABLE &&
           !IS_THIRD_PARTY && <div className="auth-panel__column">Allow cookies to sign in and comment</div>}
 
         <div className="auth-panel__column">

--- a/web/app/components/thread/getCollapsedComments.js
+++ b/web/app/components/thread/getCollapsedComments.js
@@ -1,5 +1,6 @@
 import { LS_COLLAPSE_KEY } from 'common/constants';
+import { getItem } from 'common/localStorage';
 
-const getCollapsedComments = () => JSON.parse(localStorage.getItem(LS_COLLAPSE_KEY) || '[]');
+const getCollapsedComments = () => JSON.parse(getItem(LS_COLLAPSE_KEY) || '[]');
 
 export default getCollapsedComments;

--- a/web/app/components/thread/getCollapsedComments.js
+++ b/web/app/components/thread/getCollapsedComments.js
@@ -1,6 +1,6 @@
 import { LS_COLLAPSE_KEY } from 'common/constants';
-import { getItem } from 'common/localStorage';
+import { getItem as localStorageGetItem } from 'common/localStorage';
 
-const getCollapsedComments = () => JSON.parse(getItem(LS_COLLAPSE_KEY) || '[]');
+const getCollapsedComments = () => JSON.parse(localStorageGetItem(LS_COLLAPSE_KEY) || '[]');
 
 export default getCollapsedComments;

--- a/web/app/components/thread/saveCollapsedComments.js
+++ b/web/app/components/thread/saveCollapsedComments.js
@@ -1,6 +1,6 @@
 import { LS_COLLAPSE_KEY } from 'common/constants';
-import { setItem } from 'common/localStorage';
+import { setItem as localStorageSetItem } from 'common/localStorage';
 
-const saveCollapsedComments = comments => setItem(LS_COLLAPSE_KEY, JSON.stringify(comments));
+const saveCollapsedComments = comments => localStorageSetItem(LS_COLLAPSE_KEY, JSON.stringify(comments));
 
 export default saveCollapsedComments;

--- a/web/app/components/thread/saveCollapsedComments.js
+++ b/web/app/components/thread/saveCollapsedComments.js
@@ -1,5 +1,6 @@
 import { LS_COLLAPSE_KEY } from 'common/constants';
+import { setItem } from 'common/localStorage';
 
-const saveCollapsedComments = comments => localStorage.setItem(LS_COLLAPSE_KEY, JSON.stringify(comments));
+const saveCollapsedComments = comments => setItem(LS_COLLAPSE_KEY, JSON.stringify(comments));
 
 export default saveCollapsedComments;

--- a/web/comments.ejs
+++ b/web/comments.ejs
@@ -39,8 +39,8 @@
 	  titleElement.innerHTML = '<h1>Comments for <a href="'+query.url+'">'+query.url+'</a></h1>'
 
       var remark_config = {
-        site_id: 'remark',
-        url: 'https://remark42.com/demo/',
+        site_id: query.site_id,
+        url: query.url,
       };
 
       (function () {

--- a/web/comments.ejs
+++ b/web/comments.ejs
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>remark42</title>
+
+  <style>
+    body {
+      padding: 0;
+      margin: 0;
+    }
+
+    .container {
+      max-width: 800px;
+      margin: 40px;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+	<div id="title"></div>
+    <div id="remark42"></div>
+  </div>
+
+  <script>
+    var query = (function () {
+      if (window.location.search.length === 0) return {};
+      return window.location.search.substr(1).split("&").map(function (item) {
+        return item.split("=");
+      }).reduce(function (carry, item) {
+        carry[item[0]] = decodeURIComponent(item[1]);
+        return carry;
+      }, {});
+    })()
+
+    if (query.site_id && query.url) {
+	  var titleElement = document.getElementById("title");
+	  titleElement.innerHTML = '<h1>Comments for <a href="'+query.url+'">'+query.url+'</a></h1>'
+
+      var remark_config = {
+        site_id: 'remark',
+        url: 'https://remark42.com/demo/',
+      };
+
+      (function () {
+        var d = document, s = d.createElement('script');
+        s.src = '/web/embed.js';
+        s.type = 'text/javascript';
+        (d.head || d.body).appendChild(s);
+      })();
+    }
+  </script>
+  <noscript>
+    Please enable JavaScript to view the comments powered by Remark.
+  </noscript>
+</body>
+</html>

--- a/web/comments.ejs
+++ b/web/comments.ejs
@@ -42,7 +42,7 @@
   </head>
   <body>
     <article>
-      <h1><a href="/">Remark42</a></h1>
+      <h1><a href="https://remark42.com/">Remark42</a></h1>
       <p id="title"></p>
       <div id="remark42"></div>
     </article>

--- a/web/comments.ejs
+++ b/web/comments.ejs
@@ -1,58 +1,85 @@
 <!DOCTYPE html>
-<html lang="ru">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>remark42</title>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>Remark42 demo</title>
+    <style>
+      body {
+        margin: 0;
+        padding: 20px;
+        text-align: center;
+        font: 18px/24px Helvetica, Arial, sans-serif;
+        color: #333;
+      }
 
-  <style>
-    body {
-      padding: 0;
-      margin: 0;
-    }
+      article {
+        display: block;
+        text-align: left;
+        max-width: 640px;
+        margin: 0 auto;
+      }
 
-    .container {
-      max-width: 800px;
-      margin: 40px;
-    }
-  </style>
-</head>
-<body>
-  <div class="container">
-	<div id="title"></div>
-    <div id="remark42"></div>
-  </div>
+      h1 {
+        font-size: 50px;
+        margin-left: -0.05em;
+      }
 
-  <script>
-    var query = (function () {
-      if (window.location.search.length === 0) return {};
-      return window.location.search.substr(1).split("&").map(function (item) {
-        return item.split("=");
-      }).reduce(function (carry, item) {
-        carry[item[0]] = decodeURIComponent(item[1]);
-        return carry;
-      }, {});
-    })()
+      ul {
+        color: rgb(23, 67, 78);
+      }
 
-    if (query.site_id && query.url) {
-	  var titleElement = document.getElementById("title");
-	  titleElement.innerHTML = '<h1>Comments for <a href="'+query.url+'">'+query.url+'</a></h1>'
+      a {
+        color: rgb(79, 187, 214);
+        text-decoration: none;
+      }
 
-      var remark_config = {
-        site_id: query.site_id,
-        url: query.url,
-      };
+      a:hover {
+        color: rgb(94, 167, 177);
+        text-decoration: underline;
+      }
+    </style>
+  </head>
+  <body>
+    <article>
+      <h1><a href="/">Remark42</a></h1>
+      <p id="title"></p>
+      <div id="remark42"></div>
+    </article>
 
-      (function () {
-        var d = document, s = d.createElement('script');
-        s.src = '/web/embed.js';
-        s.type = 'text/javascript';
-        (d.head || d.body).appendChild(s);
+    <script>
+      var query = (function() {
+        if (window.location.search.length === 0) return {};
+        return window.location.search
+          .substr(1)
+          .split('&')
+          .map(function(item) {
+            return item.split('=');
+          })
+          .reduce(function(carry, item) {
+            carry[item[0]] = decodeURIComponent(item[1]);
+            return carry;
+          }, {});
       })();
-    }
-  </script>
-  <noscript>
-    Please enable JavaScript to view the comments powered by Remark.
-  </noscript>
-</body>
+
+      if (query.site_id && query.url) {
+        var titleElement = document.getElementById('title');
+        titleElement.innerHTML = 'Comments for <a href="' + query.url + '">' + query.url + '</a>';
+
+        var remark_config = {
+          site_id: query.site_id,
+          url: query.url,
+        };
+
+        (function() {
+          var d = document,
+            s = d.createElement('script');
+          s.src = '/web/embed.js';
+          s.type = 'text/javascript';
+          (d.head || d.body).appendChild(s);
+        })();
+      }
+    </script>
+    <noscript> Please enable JavaScript to view the comments powered by Remark. </noscript>
+  </body>
 </html>

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -114,6 +114,11 @@ module.exports = {
       filename: 'last-comments.html',
       inject: false,
     }),
+    new Html({
+      template: path.resolve(__dirname, 'comments.ejs'),
+      filename: 'comments.html',
+      inject: false,
+    }),
     new ExtractText({
       filename: `remark.css`,
       allChunks: true,


### PR DESCRIPTION
Related to #218 

When using Firefox with "block third-party cookies: all" setting, the comments iframe fails with "the operation is insecure" error message.
Crash caused by call of any method of localStorage.
Current pr adds check if storage available and if not shows placeholder below instead of "Sign in with..."

![screen shot 2018-11-14 at 06 51 07](https://user-images.githubusercontent.com/884649/48459031-c8f1a800-e7d9-11e8-8612-86fbf6439bc2.png)
By clicking on a "new page" user relocated to new page with the same origin as an iframe (template is  `/web/comments.ejs`)
If user blocked cookies completely placeholder will be the following

![screen shot 2018-11-14 at 07 04 08](https://user-images.githubusercontent.com/884649/48459707-5d5d0a00-e7dc-11e8-825b-bfd2f392b0bc.png)

Current solution was tested mainly with Firefox, Safari seems to allow cookies even with "Prevent cross-site tracking" turned on.
