### PR TITLE
Dynamic comment's node watching

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Remark42 is a self-hosted, lightweight, and simple (yet functional) comment engi
 
   - [Install](#install)
     - [Backend](#backend)
-      - [With Docker](#with-docker) 
-      - [Without docker](#without-docker) 
+      - [With Docker](#with-docker)
+      - [Without docker](#without-docker)
       - [Parameters](#parameters)
         - [Required parameters](#required-parameters)
       - [Register oauth2 providers](#register-oauth2-providers)
@@ -76,7 +76,7 @@ _this is the recommended way to run remark42_
 #### Without docker
 
 * download archive for [stable release](https://github.com/umputun/remark/releases) or [development version](https://remark42.com/downloads)
-* unpack with `gunzip` (Linux, macOS) or with `zip` (Windows) 
+* unpack with `gunzip` (Linux, macOS) or with `zip` (Windows)
 * run as `remark42.{os}-{arch} server {parameters...}`, i.e. `remark42.linux-amd64 server --secret=12345 --url=http://127.0.0.1:8080`
 * alternatively compile from the sources - `make OS=[linux|darwin|windows] ARCH=[amd64,386,arm64,arm32]`
 
@@ -137,7 +137,7 @@ _this is the recommended way to run remark42_
 
 ##### Required parameters
 
-Most of the parameters have sane defaults and don't require customization. There are only a few parameters user has to define:  
+Most of the parameters have sane defaults and don't require customization. There are only a few parameters user has to define:
 
 1. `SECRET` - secret key, can be any long and hard-to-guess string.
 2. `REMARK_URL` - url pointing to your remark42 server, i.e. `https://demo.reamark42.com`
@@ -160,7 +160,7 @@ services:
             - AUTH_GITHUB_CID=12345667890           # oauth2 client ID
             - AUTH_GITHUB_CSEC=abcdefg12345678      # oauth2 client secret
         volumes:
-            - ./var:/srv/var                        # persistent volume to store all remark42 data 
+            - ./var:/srv/var                        # persistent volume to store all remark42 data
 ```
 
 #### Register oauth2 providers
@@ -223,7 +223,7 @@ For more details refer to [Yandex OAuth](https://tech.yandex.com/oauth/doc/dg/co
 
 #### Initial import from WordPress
 
-1. Install WordPress [plugin](https://wordpress.org/plugins/wp-exporter/) to export comments and follow it instructions. The plugin should produce a xml-based file with site content including comments. 
+1. Install WordPress [plugin](https://wordpress.org/plugins/wp-exporter/) to export comments and follow it instructions. The plugin should produce a xml-based file with site content including comments.
 2. Move this file to your remark42 host within `./var`
 3. Run import command - `docker exec -it remark42 import -p wordpress -f {wordpress-export-name}.xml -s {your site id}`
 
@@ -251,25 +251,25 @@ Restore will clean all comments first and then will processed with complete impo
 ##### Backup format
 
 Backup file is a text file with all exported comments separated by EOL. Each backup record is a valid json with all key/value
-unmarshaled from `Comment` struct (see below). 
+unmarshaled from `Comment` struct (see below).
 
 #### Admin users
 
-Admins/moderators should be defined in `docker-compose.yml` as a list of user IDs or passed in the command line. 
+Admins/moderators should be defined in `docker-compose.yml` as a list of user IDs or passed in the command line.
 
 ```
     environment:
         - ADMIN=github_ef0f706a79cc24b17bbbb374cd234a691a034128,github_dae9983158e9e5e127ef2b87a411ef13c891e9e5
 ```
 
-To get user id just login and click on your username or any other user you want to promote to admins. 
+To get user id just login and click on your username or any other user you want to promote to admins.
 It will expand login info and show full user ID.
 
 ### Setup on your website
 
 #### Comments
 
-It's a main widget which renders list of comments. 
+It's a main widget which renders list of comments.
 
 Add this snippet to the bottom of web page:
 
@@ -278,7 +278,7 @@ Add this snippet to the bottom of web page:
   var remark_config = {
     site_id: 'YOUR_SITE_ID',
     url: 'PAGE_URL', // optional param; if it isn't defined window.location.href will be used
-    max_shown_comments: 10, // optional param; if it isn't defined default value (15) will be used 
+    max_shown_comments: 10, // optional param; if it isn't defined default value (15) will be used
   };
 
   (function() {
@@ -293,7 +293,7 @@ And then add this node in the place where you want to see Remark42 widget:
 
 ```html
 <div id="remark42"></div>
-``` 
+```
 
 After that widget will be rendered inside this node.
 
@@ -306,7 +306,7 @@ Add this snippet to the bottom of web page:
 ```html
 <script>
   var remark_config = {
-    site_id: 'YOUR_SITE_ID', 
+    site_id: 'YOUR_SITE_ID',
   };
 
   (function() {
@@ -351,18 +351,18 @@ And then add a node like this in the place where you want to see a number of com
 <span class="remark42__counter" data-url="https://domain.com/path/to/article/"></span>
 ```
 
-You can use as many nodes like this as you need to. 
-The script will found all them by the class `remark__counter`, 
+You can use as many nodes like this as you need to.
+The script will found all them by the class `remark__counter`,
 and it will use `data-url` attribute to define the page with comments.
 
-Also script can uses `url` property from `remark_config` object, or `window.location.href` if nothing else is defined. 
+Also script can uses `url` property from `remark_config` object, or `window.location.href` if nothing else is defined.
 
 ## Build from the source
 
 - to build docker container - `make docker`. This command will produce container `umputun/remark42`.
-- to build a single binary for direct execution - `make OS=<linux|windows|darwin> ARCH=<amd64|386>`. This step will produce executable 
+- to build a single binary for direct execution - `make OS=<linux|windows|darwin> ARCH=<amd64|386>`. This step will produce executable
  `remark42` file with everything embedded.
- 
+
 ## Development
 
 You can use fully functional local version to develop and test both frontend & backend.
@@ -380,11 +380,11 @@ docker-compose -f compose-dev-frontend.yml up
 
 It starts Remark42 on `127.0.0.1:8080` and adds local OAuth2 provider “Dev”.
 To access UI demo page go to `127.0.0.1:8080/web`.
-By default, you would be logged in as `dev_user` which defined as admin. 
+By default, you would be logged in as `dev_user` which defined as admin.
 You can tweak any of [supported parameters](#Parameters) in corresponded yml file.
 
-Backend docker compose config by default skips running frontend related tests. 
-Frontend docker compose config by default skips running backend related tests and sets `NODE_ENV=development` for frontend build. 
+Backend docker compose config by default skips running frontend related tests.
+Frontend docker compose config by default skips running backend related tests and sets `NODE_ENV=development` for frontend build.
 
 ### Backend development
 
@@ -498,7 +498,7 @@ Sort can be `time`, `active` or `score`. Supported sort order with prefix -/+, i
  	type EditRequest struct {
  		Text    string `json:"text"`    // updated text
  		Summary string `json:"summary"` // optional, summary of the edit
- 		Delete  bool   `json:"delete"`  // delete flag 
+ 		Delete  bool   `json:"delete"`  // delete flag
  	}{}
 ```
 
@@ -538,11 +538,11 @@ Sort can be `time`, `active` or `score`. Supported sort order with prefix -/+, i
       LowScore      int      `json:"low_score"`
       CriticalScore int      `json:"critical_score"`
   }
-  ``` 
+  ```
 * `GET /api/v1/info?site=site-idd&url=post-ur` - returns `PostInfo` for site and url
-  
+
 ### RSS feeds
-  
+
 * `GET /api/v1/rss/post?site=site-id&url=post-url` - rss feed for a post
 * `GET /api/v1/rss/site?site=site-id` - rss feed for given site
 * `GET /api/v1/rss/reply?site=site-id&user=user-id` - rss feed for replies to user's comments
@@ -570,7 +570,7 @@ Sort can be `time`, `active` or `score`. Supported sort order with prefix -/+, i
 
 _all admin calls require auth and admin privilege_
 
-## Privacy 
+## Privacy
 
 * Remark42 is trying to be very sensitive to any private or semi-private information.
 * Authentication requesting the minimal possible scope from authentication providers. All extra information returned by them dropped immediately and not stored in any form.
@@ -581,7 +581,7 @@ _all admin calls require auth and admin privilege_
 * There are no third-party analytic services involved.
 * User can request all information remark42 knows about and export to gz file.
 * Supported complete cleanup of all information related to user's activity.
-* Cookie lifespan can be restricted to session-only. 
+* Cookie lifespan can be restricted to session-only.
 * All potentially sensitive data stored by remark42 hashed and encrypted.
 
 ## Technical details

--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ Add this snippet to the bottom of web page:
 	selector: "#remark42" // optional param; string|HTMLElement; Selector by which remark should mount comments iframe
     url: 'PAGE_URL', // optional param; if it isn't defined window.location.href will be used
     max_shown_comments: 10, // optional param; if it isn't defined default value (15) will be used
+	dynamic: false // optional; boolean; if enabled, then remark would watch for dynamic node removing/adding. Useful for SPA
   };
 
   (function() {

--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ Add this snippet to the bottom of web page:
 <script>
   var remark_config = {
     site_id: 'YOUR_SITE_ID',
+	selector: "#remark42" // optional param; string|HTMLElement; Selector by which remark should mount comments iframe
     url: 'PAGE_URL', // optional param; if it isn't defined window.location.href will be used
     max_shown_comments: 10, // optional param; if it isn't defined default value (15) will be used
   };
@@ -296,6 +297,14 @@ And then add this node in the place where you want to see Remark42 widget:
 ```
 
 After that widget will be rendered inside this node.
+
+The node also supports overriding remark's config with `data` attributes, like:
+
+```
+<div id="remark42" data-url="https://example.com"></div>
+```
+
+Available attributes are `data-site-id`, `data-url`, `data-max-shown-comments`
 
 #### Last comments
 

--- a/web/app/embed.js
+++ b/web/app/embed.js
@@ -246,7 +246,7 @@ function init() {
     return;
   }
 
-  if (typeof remark_config.selector === 'string' && window.MutationObserver) {
+  if (remark_config.dynamic && typeof remark_config.selector === 'string' && window.MutationObserver) {
     const observer = new MutationObserver(mutationList => {
       for (let record of mutationList) {
         for (let node of record.addedNodes) {


### PR DESCRIPTION
Related to #220 

This PR adds ability for Remark to watch for comment's node adding/removing dynamically via MutationObserver. This solves the the problem I've stumbled while working on https://github.com/radio-t/rtnews-ui . It uses History API navigation, so remark's node can be added to the DOM not only at initial load, but at any time. To solve this, I had to copy/paste [`embed.js` and tweak it a bit](https://github.com/radio-t/rtnews-ui/blob/0ff0ea3547cc90b4e12aa2c5f34c6527664243d9/src/remark.jsx#L11-L264). This is not only looking ugly as hell, but also very inconvenient cause if Remark's node handling will change, I should recopy/repaste and apply tweaks again and maintain initialization/deinitialization myself.

Also, PR adds ability to define custom selector or straight HTMLElement, not only `#remark42`. This is useful, if you for example want set id to "#comments", or track by class.

**Downside:** Solution uses MutationObserver which watch for any hierarchy change in document.body. This could be useless if website is not dynamic. So, I added boolean `dynamic` flag set to `false` by default.
Also, if browser doesn't support Mutation observer, the user will be left with it as is.

**Backwards compatibility:** compatible

------
I [used plain array](https://github.com/Reeywhaar/remark/blob/4d0bef74df1d79a06cc93613cd9d80f2a905af09/web/app/embed.js#L233) to store initialized nodes info. But `WeakMap` is more suitable for such case, but it's support though is very good, but is still questionable, depending on which platforms do you plan to support, like ie10, 11?

------
I noticed that same logic may be applied to `counter` and `last comments` pages. So, I wonder, do I have a point with this pr, guys? Or maybe another approach could take place. Like Initializing global `Remark` object with `initNode`, `deinitNode` methods?