### PR TITLE
fixed zero vote limit not respected and treated as unlimited

### DIFF
--- a/backend/app/rest/api/rest_test.go
+++ b/backend/app/rest/api/rest_test.go
@@ -98,6 +98,7 @@ func prep(t *testing.T) (srv *Rest, ts *httptest.Server) {
 		EditDuration:   5 * time.Minute,
 		MaxCommentSize: 4000,
 		AdminStore:     adminStore,
+		MaxVotes:       -1,
 	}
 	srv = &Rest{
 		DataService: dataStore,

--- a/backend/app/store/service/service.go
+++ b/backend/app/store/service/service.go
@@ -100,7 +100,7 @@ func (s *DataStore) Vote(locator store.Locator, commentID string, userID string,
 	}
 
 	maxVotes := s.MaxVotes
-	if s.MaxVotes <= 0 {
+	if s.MaxVotes < 0 {
 		maxVotes = defaultVotesLimit
 	}
 

--- a/backend/app/store/service/service_test.go
+++ b/backend/app/store/service/service_test.go
@@ -73,7 +73,7 @@ func TestService_CreateFromPartial(t *testing.T) {
 
 func TestService_Vote(t *testing.T) {
 	defer os.Remove(testDb)
-	b := DataStore{Interface: prepStoreEngine(t), AdminStore: admin.NewStaticKeyStore("secret 123")}
+	b := DataStore{Interface: prepStoreEngine(t), AdminStore: admin.NewStaticKeyStore("secret 123"), MaxVotes: -1}
 
 	comment := store.Comment{
 		Text:    "text",
@@ -134,9 +134,18 @@ func TestService_VoteLimit(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestService_VotesDisabled(t *testing.T) {
+	defer os.Remove(testDb)
+	b := DataStore{Interface: prepStoreEngine(t), AdminStore: admin.NewStaticKeyStore("secret 123"), MaxVotes: 0}
+
+	_, err := b.Vote(store.Locator{URL: "https://radio-t.com", SiteID: "radio-t"}, "id-1", "user2", true)
+	assert.NotNil(t, err, "vote limit reached")
+	assert.True(t, strings.HasPrefix(err.Error(), "maximum number of votes exceeded for comment id-1"))
+}
+
 func TestService_VoteAggressive(t *testing.T) {
 	defer os.Remove(testDb)
-	b := DataStore{Interface: prepStoreEngine(t), AdminStore: admin.NewStaticKeyStore("secret 123")}
+	b := DataStore{Interface: prepStoreEngine(t), AdminStore: admin.NewStaticKeyStore("secret 123"), MaxVotes: -1}
 
 	comment := store.Comment{
 		Text:    "text",
@@ -196,7 +205,7 @@ func TestService_VoteAggressive(t *testing.T) {
 func TestService_VoteConcurrent(t *testing.T) {
 
 	defer os.Remove(testDb)
-	b := DataStore{Interface: prepStoreEngine(t), AdminStore: admin.NewStaticKeyStore("secret 123")}
+	b := DataStore{Interface: prepStoreEngine(t), AdminStore: admin.NewStaticKeyStore("secret 123"), MaxVotes: -1}
 
 	comment := store.Comment{
 		Text:    "text",


### PR DESCRIPTION
Hello.

Messed up a little with #207 yesterday.
Now it is truly possible to disable voting by setting vote limit to zero.