### PR TITLE
Reset opacity for useless comment by mouse hover event

### DIFF
--- a/web/app/components/comment/_useless/comment_useless.scss
+++ b/web/app/components/comment/_useless/comment_useless.scss
@@ -1,5 +1,8 @@
 .comment_useless {
   .comment__body {
     opacity: 0.35;
+    &:hover {
+      opacity: 1;
+    }
   }
 }


### PR DESCRIPTION
Let's show useless comments when user hovers them. 