### PR TITLE
simplify makeDirs()

### DIFF
--- a/backend/app/cmd/cmd.go
+++ b/backend/app/cmd/cmd.go
@@ -101,28 +101,11 @@ func responseError(resp *http.Response) error {
 
 // mkdir -p for all dirs
 func makeDirs(dirs ...string) error {
-
-	// exists returns whether the given file or directory exists or not
-	exists := func(path string) (bool, error) {
-		_, err := os.Stat(path)
-		if err == nil {
-			return true, nil
-		}
-		if os.IsNotExist(err) {
-			return false, nil
-		}
-		return true, err
-	}
-
 	for _, dir := range dirs {
-		ex, err := exists(dir)
-		if err != nil {
-			return errors.Wrapf(err, "can't check directory status for %s", dir)
-		}
-		if !ex {
-			if e := os.MkdirAll(dir, 0700); e != nil {
-				return errors.Wrapf(err, "can't make directory %s", dir)
-			}
+		// From docs: "If path is already a directory, MkdirAll does nothing
+		// and returns nil".
+		if err := os.MkdirAll(dir, 0700); err != nil {
+			return errors.Wrapf(err, "can't make directory %s", dir)
 		}
 	}
 	return nil


### PR DESCRIPTION
I propose to simplify makeDirs() function.
(Note that current implementation of makeDirs() contains a bug on the line 124 - it does not wrap right error variable. It also does not check whether existed path is a directory.)