### PR TITLE
Disable comment editing if it has reply

### DIFF
--- a/web/app/components/comment/comment.jsx
+++ b/web/app/components/comment/comment.jsx
@@ -391,6 +391,7 @@ export default class Comment extends Component {
     const lowCommentScore = config.low_score;
     const votingDisabledReason = this.getVoteDisabledReason();
     const isVotingDisabled = votingDisabledReason !== null;
+    const editable = data.repliesCount === 0 && !!editTimeLeft;
 
     const o = {
       ...data,
@@ -588,7 +589,7 @@ export default class Comment extends Component {
               !mods.disabled &&
               !!o.orig &&
               isCurrentUser &&
-              (!!editTimeLeft || isEditing) &&
+              (editable || isEditing) &&
               mods.view !== 'user' && [
                 <span
                   {...getHandleClickProps(this.toggleEditing)}

--- a/web/app/components/input/input.jsx
+++ b/web/app/components/input/input.jsx
@@ -21,6 +21,7 @@ export default class Input extends Component {
     this.state = {
       preview: null,
       isErrorShown: false,
+      errorMessage: null,
       isDisabled: false,
       maxLength: config.max_comment_size || DEFAULT_MAX_COMMENT_SIZE,
       text: props.value || '',
@@ -60,6 +61,7 @@ export default class Input extends Component {
     this.setState({
       preview: null,
       isErrorShown: false,
+      errorMessage: null,
       text: e.target.value,
     });
   }
@@ -87,8 +89,17 @@ export default class Input extends Component {
 
         this.setState({ preview: null, text: '' });
       })
-      .catch(() => {
-        this.setState({ isErrorShown: true });
+      .catch(e => {
+        if (
+          e.response &&
+          e.response.data &&
+          typeof e.response.data.error === 'string' &&
+          e.response.data.error.indexOf("parent comment with reply can't be edited") === 0
+        ) {
+          this.setState({ isErrorShown: true, errorMessage: 'Comment has reply, editing is not possible' });
+          return;
+        }
+        this.setState({ isErrorShown: true, errorMessage: null });
       })
       .finally(() => this.setState({ isDisabled: false }));
   }
@@ -98,19 +109,20 @@ export default class Input extends Component {
 
     if (!text || !text.trim()) return;
 
-    this.setState({ isErrorShown: false });
+    this.setState({ isErrorShown: false, errorMessage: null });
 
     api
       .getPreview({ text })
       .then(preview => this.setState({ preview }))
       .catch(() => {
-        this.setState({ isErrorShown: true });
+        this.setState({ isErrorShown: true, errorMessage: null });
       });
   }
 
-  render(props, { isDisabled, isErrorShown, preview, maxLength, text }) {
+  render(props, { isDisabled, isErrorShown, errorMessage, preview, maxLength, text }) {
     const charactersLeft = maxLength - text.length;
-    const { mods = {}, errorMessage, userId } = props;
+    const { mods = {}, userId } = props;
+    errorMessage = props.errorMessage || errorMessage;
 
     return (
       <form className={b('input', props)} onSubmit={this.send} aria-label="New comment">

--- a/web/app/components/input/input.jsx
+++ b/web/app/components/input/input.jsx
@@ -74,6 +74,11 @@ export default class Input extends Component {
 
     if (!text || !text.trim()) return;
 
+    if (text === this.props.value) {
+      this.props.onCancel && this.props.onCancel();
+      this.setState({ preview: null, text: '' });
+    }
+
     this.setState({ isDisabled: true, isErrorShown: false });
 
     const request =
@@ -83,10 +88,7 @@ export default class Input extends Component {
 
     request
       .then(comment => {
-        if (this.props.onSubmit) {
-          this.props.onSubmit(comment);
-        }
-
+        this.props.onSubmit && this.props.onSubmit(comment);
         this.setState({ preview: null, text: '' });
       })
       .catch(e => {

--- a/web/app/components/thread/thread.jsx
+++ b/web/app/components/thread/thread.jsx
@@ -31,7 +31,7 @@ class Thread extends Component {
         aria-expanded={!collapsed}
       >
         <Comment
-          data={comment}
+          data={{ ...comment, repliesCount: replies.length }}
           isCommentsDisabled={isCommentsDisabled}
           mods={{ level: mods.level, collapsed }}
           onReply={props.onReply}


### PR DESCRIPTION
Frontend side for #248

* If comment has reply then edit button is hidden.
* if user started to edit comment, before someone replied, and then clicks on `send`, the following message will be shown:
![screenshot 2019-01-16 at 23 43 55](https://user-images.githubusercontent.com/884649/51277542-f846b000-19e8-11e9-9a59-42ec3ed11720.png)
* if value of edit textarea is the same as original comment (user clicked edit, but haven't typed anything), then on `send` click edit input will be hidden (like if edit passed)
