### PR TITLE
Add check for comments unexpected value

### DIFF
--- a/web/app/common/api.js
+++ b/web/app/common/api.js
@@ -11,9 +11,25 @@ export const logOut = () => fetcher.get({ url: `/auth/logout`, overriddenApiBase
 export const getConfig = () => fetcher.get(`/config`);
 
 // TODO: looks like we can get url from settings here and below
-export const getPostComments = ({ sort, url }) => fetcher.get(`/find?url=${url}&sort=${sort}&format=tree`);
+export const getPostComments = ({ sort, url }) =>
+  fetcher.get(`/find?url=${url}&sort=${sort}&format=tree`).then(data => {
+    if (typeof data !== 'object') data = { comments: [], info: {} };
 
-export const getLastComments = ({ siteId, max }) => fetcher.get(`/last/${max}?site=${siteId}`);
+    if (!data.hasOwnProperty('comments')) data.comments = [];
+    // cheap check for typeodf comments === "array"
+    if (!(data.comments !== null && typeof data.comments === 'object' && 'length' in data.comments)) data.comments = [];
+
+    if (!data.hasOwnProperty('info')) data.info = {};
+    if (!(data.info !== null && typeof data.comments === 'object')) data.comments = {};
+
+    return data;
+  });
+
+export const getLastComments = ({ siteId, max }) =>
+  fetcher.get(`/last/${max}?site=${siteId}`).then(comments => {
+    if (!(comments !== null && typeof comments === 'object' && 'length' in comments)) comments = [];
+    return comments;
+  });
 
 export const getCommentsCount = ({ urls, siteId }) =>
   fetcher.post({

--- a/web/app/components/root/root.jsx
+++ b/web/app/components/root/root.jsx
@@ -94,7 +94,10 @@ export default class Root extends Component {
           store.set('comments', comments);
           store.set('info', info);
         })
-        .catch(() => store.set('comments', [])),
+        .catch(() => {
+          store.set('comments', []);
+          store.set('info', {});
+        }),
     ]).finally(() => {
       this.setState({
         isLoaded: true,


### PR DESCRIPTION
To https://github.com/umputun/remark/issues/262

Added fix in case if `/api/v1/find` or `/api/v1/last` returns `null` value for comments. Should remark that this check can be avoided if we agree that server must always return empty list for comments if there aren't any. Though there is a slight difference, because `null` value implies that there were no comments before, while `[]` value indicates that there were some but were removed. It's either an inconsistency or a feature :-)