### PR TITLE
do not add .git folder to a build layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,6 @@ ARG MONGO_TEST
 
 WORKDIR /go/src/github.com/umputun/remark/backend
 ADD backend /go/src/github.com/umputun/remark/backend
-ADD .git /go/src/github.com/umputun/remark/.git
 
 # run tests
 RUN \


### PR DESCRIPTION
`.git` folder isn't present in tarballs pulled from releases, e.g. `wget https://github.com/umputun/remark/archive/v.1.2.1.tar.gz`, and not used during the build anyways