### PR TITLE
Fix comment typo

### DIFF
--- a/backend/app/rest/api/rest_public.go
+++ b/backend/app/rest/api/rest_public.go
@@ -263,7 +263,7 @@ func (s *Rest) countCtrl(w http.ResponseWriter, r *http.Request) {
 	render.JSON(w, r, R.JSON{"count": count, "locator": locator})
 }
 
-// POST /count?site=siteID - get number of comments for posts from post body
+// POST /counts?site=siteID - get number of comments for posts from post body
 func (s *Rest) countMultiCtrl(w http.ResponseWriter, r *http.Request) {
 	siteID := r.URL.Query().Get("site")
 	posts := []string{}


### PR DESCRIPTION
Method Rest.countMultiCtrl() is actually mounted on the route "/counts".

https://github.com/umputun/remark/blob/3471c5dab8ac2c2e52cc1daa0684b222196717e4/backend/app/rest/api/rest.go#L217
