### PR TITLE
Fix block users select behavior

### DIFF
--- a/web/app/utils/debounce.js
+++ b/web/app/utils/debounce.js
@@ -1,0 +1,8 @@
+export default function debounce(func, wait) {
+  let timeout;
+  return function() {
+    const laterCall = () => func.apply(this, arguments);
+    clearTimeout(timeout);
+    timeout = setTimeout(laterCall, wait);
+  };
+}


### PR DESCRIPTION
https://github.com/umputun/remark/issues/148

We need to have onBlur and onChange events listeners for the select for the "block user" as it advised by es-lint. But if we simply add onBlur event listener it will cause infinite loop of blur -> confirm pop-up -> cancel -> blur -> confirm pop-up... So we have to debounce the events to process them only one time.