### PR TITLE
Hanlde limiter rejection on UI side

### DIFF
--- a/backend/app/rest/httperrors.go
+++ b/backend/app/rest/httperrors.go
@@ -25,7 +25,7 @@ const (
 	ErrReadOnly           = 8  // write failed on read only
 	ErrCommentRejected    = 9  // general error on rejected comment change
 	ErrCommentEditExpired = 10 // too late for edit
-	ErrCommentEditChanged = 11 // parent commend changed
+	ErrCommentEditChanged = 11 // parent comment cannot be changed
 	ErrVoteRejected       = 12 // general error on vote rejected
 	ErrVoteSelf           = 13 // vote for own comment
 	ErrVoteDbl            = 14 // already voted for the comment

--- a/web/app/components/comment/__vote/comment__vote.scss
+++ b/web/app/components/comment/__vote/comment__vote.scss
@@ -9,3 +9,11 @@
   background-size: contain;
   cursor: pointer;
 }
+
+.voting__error {
+  color: #9a0000;
+  text-align: right;
+  font-size: 14px;
+  line-height: 1;
+  margin-top: -10px;
+}

--- a/web/app/components/input/input.jsx
+++ b/web/app/components/input/input.jsx
@@ -6,6 +6,7 @@ import { siteId, url, pageTitle } from 'common/settings';
 
 import api from 'common/api';
 import store from 'common/store';
+import { extractErrorMessageFromResponse } from 'utils/errorUtils';
 import TextareaAutosize from 'components/input/textarea-autosize';
 
 const RSS_THREAD_URL = `${BASE_URL}${API_BASE}/rss/post?site=${siteId}&url=${url}`;
@@ -92,16 +93,8 @@ export default class Input extends Component {
         this.setState({ preview: null, text: '' });
       })
       .catch(e => {
-        if (
-          e.response &&
-          e.response.data &&
-          typeof e.response.data.error === 'string' &&
-          e.response.data.error.indexOf("parent comment with reply can't be edited") === 0
-        ) {
-          this.setState({ isErrorShown: true, errorMessage: 'Comment has reply, editing is not possible' });
-          return;
-        }
-        this.setState({ isErrorShown: true, errorMessage: null });
+        const errorMessage = extractErrorMessageFromResponse(e.response);
+        this.setState({ isErrorShown: true, errorMessage });
       })
       .finally(() => this.setState({ isDisabled: false }));
   }

--- a/web/app/utils/errorUtils.js
+++ b/web/app/utils/errorUtils.js
@@ -1,0 +1,44 @@
+const errorMessageForCodes = new Map([
+  [0, 'Something went wrong. Please try again a bit later.'],
+  [1, 'Comment cannot be found. Please refresh the page and try again.'],
+  [2, 'Failed to unmarshal incoming request.'],
+  [3, "You don't have permission for this operaton."],
+  [4, 'Invalid comment data.'],
+  [5, 'Comment cannot be found.  Please refresh the page and try again.'],
+  [6, 'Site cannot be found.  Please refresh the page and try again.'],
+  [7, 'User has been blocked.'],
+  [8, 'This post is read only.'],
+  [9, 'Comment changing failed. Please try again a bit later.'],
+  [10, 'It is too late to edit the comment.'],
+  [11, 'Comment already has reply, editing is not possible.'],
+  [12, 'Cannot save voting result. Please try again a bit later.'],
+  [13, 'You cannot vote for your own comment.'],
+  [14, 'You have already voted for the comment.'],
+  [15, 'Too many votes for the comment.'],
+  [16, 'Min score reached for the comment.'],
+  [17, 'Action rejected. Please try again a bit later.'],
+  [18, 'Requested file cannot be found.'],
+]);
+
+export function extractErrorMessageFromResponse(response) {
+  const defatulErrorMessage = 'Something went wrong. Please try again a bit later.';
+  if (!(response && response.data)) {
+    return defatulErrorMessage;
+  }
+
+  const responseData = response.data;
+
+  if (typeof responseData.code === 'number' && errorMessageForCodes.has(responseData.code)) {
+    return errorMessageForCodes.get(responseData.code);
+  }
+
+  if (typeof responseData.details === 'string') {
+    return responseData.details;
+  }
+
+  if (typeof responseData === 'string') {
+    return responseData;
+  }
+
+  return defatulErrorMessage;
+}


### PR DESCRIPTION
Issue https://github.com/umputun/remark/issues/256

- Adds common function to get error message from the http response
- Adds error message for the voting request failure displayed under the voting buttons
- Adds restoring of voting data after voting request failed

Example of the error message:

<img width="812" alt="image" src="https://user-images.githubusercontent.com/3448822/52521369-97de2200-2cb9-11e9-86ba-e7db0d9a243a.png">

Handling error when user has been blocked:
<img width="821" alt="image" src="https://user-images.githubusercontent.com/3448822/52521387-d7a50980-2cb9-11e9-8f47-91c67aa753e8.png">
