### PR TITLE
Add "contradiction index" metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,6 +489,7 @@ type Comment struct {
     Locator   Locator         `json:"locator"` // post locator
     Score     int             `json:"score"`   // comment score, read only
     Votes     map[string]bool `json:"votes"`   // comment votes, read only
+    Controversy float64       `json:"controversy,omitempty"` // comment controversy, read only
     Timestamp time.Time       `json:"time"`    // time stamp, read only
     Pin       bool            `json:"pin"`     // pinned status, read only
     Delete    bool            `json:"delete"`  // delete status, read only

--- a/web/app/components/auth-panel/auth-panel.jsx
+++ b/web/app/components/auth-panel/auth-panel.jsx
@@ -188,6 +188,14 @@ function getSortArray(currentSort) {
       value: '+active',
       label: 'Least recently updated',
     },
+    {
+      value: '-controversy',
+      label: 'Most controversial',
+    },
+    {
+      value: '+controversy',
+      label: 'Least controversial',
+    },
   ];
 
   return sortArray.map(sort => {

--- a/web/app/components/comment/comment.jsx
+++ b/web/app/components/comment/comment.jsx
@@ -446,6 +446,7 @@ export default class Comment extends Component {
 
     const o = {
       ...data,
+      controversyText: `Controversy: ${(data.controversy || 0).toFixed(2)}`,
       text: data.text.length
         ? mods.view === 'preview'
           ? getTextSnippet(data.text)
@@ -603,7 +604,7 @@ export default class Comment extends Component {
                 Vote up
               </span>
 
-              <span className="comment__score-value">
+              <span className="comment__score-value" title={o.controversyText}>
                 {o.score.sign}
                 {o.score.value}
               </span>


### PR DESCRIPTION
Issue https://github.com/umputun/remark/issues/274
* show the value of `controversy` in the hover on scores: value if it exists,
  "No controversy." if value is zero, "No votes yet." if there are no votes.
* add a new sorting mode "controversial" to "sort by" dropdown

<img width="907" alt="image" src="https://user-images.githubusercontent.com/3448822/52912411-7f42bd00-32f4-11e9-8139-60d6da2d8ed3.png">

<img width="895" alt="image" src="https://user-images.githubusercontent.com/3448822/52912418-941f5080-32f4-11e9-8259-e4a383050469.png">

<img width="890" alt="image" src="https://user-images.githubusercontent.com/3448822/52912420-a7cab700-32f4-11e9-9601-fb8021656ea9.png">
