### PR TITLE
Fix comment input top margin in editing or replying mode

### DIFF
--- a/web/app/components/comment/_editing/comment_editing.scss
+++ b/web/app/components/comment/_editing/comment_editing.scss
@@ -5,6 +5,7 @@
 
   .comment__input {
     border: 12px solid;
+    border-top-width: 6px;
   }
 
   .comment__score {

--- a/web/app/components/comment/_replying/comment_replying.scss
+++ b/web/app/components/comment/_replying/comment_replying.scss
@@ -1,6 +1,7 @@
 .comment_replying {
   .comment__input {
     border: 12px solid;
+    border-top-width: 6px;
   }
 
   .comment__score {


### PR DESCRIPTION
to #314
![Screenshot 2019-04-21 at 23 11 12](https://user-images.githubusercontent.com/884649/56475024-4c9b7900-648b-11e9-9727-bb70d77dae72.png)
