### PR TITLE
Info stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -624,7 +624,8 @@ Sort can be `time`, `active` or `score`. Supported sort order with prefix -/+, i
   }
   ```
 
-* `GET /api/v1/info?site=site-idd&url=post-ur` - returns `PostInfo` for site and url
+* `GET /api/v1/info?site=site-idd&url=post-url` - returns `PostInfo` for site and url
+* `GET /api/v1/stream/info?site=site-idd&url=post-url` - returns stream with `PostInfo` records ("\n" separated) for site and url`
 
 ### RSS feeds
 

--- a/backend/app/cmd/server.go
+++ b/backend/app/cmd/server.go
@@ -304,6 +304,8 @@ func (s *ServerCommand) newServerApp() (*serverApp, error) {
 		SSLConfig:        sslConfig,
 		UpdateLimiter:    s.UpdateLimit,
 		ImageService:     imageService,
+		StreamTimeOut:    time.Minute * 15,
+		StreamRefresh:    time.Second,
 	}
 
 	srv.ScoreThresholds.Low, srv.ScoreThresholds.Critical = s.LowScore, s.CriticalScore

--- a/backend/app/rest/api/rest.go
+++ b/backend/app/rest/api/rest.go
@@ -240,12 +240,10 @@ func (s *Rest) routes() chi.Router {
 
 		})
 
-		// open routes, streams
+		// open routes, streams, no send timeout
 		rapi.Route("/stream", func(rstream chi.Router) {
-			rstream.Use(middleware.Timeout(s.StreamTimeOut + time.Second))
 			rstream.Use(tollbooth_chi.LimitHandler(tollbooth.NewLimiter(10, nil)))
 			rstream.Use(authMiddleware.Trace, middleware.NoCache, logInfoWithBody)
-
 			rstream.Get("/info", s.pubRest.infoStreamCtrl)
 		})
 

--- a/backend/app/rest/api/rest.go
+++ b/backend/app/rest/api/rest.go
@@ -55,6 +55,9 @@ type Rest struct {
 	}
 	UpdateLimiter float64
 
+	StreamTimeOut time.Duration
+	StreamRefresh time.Duration
+
 	SSLConfig   SSLConfig
 	httpsServer *http.Server
 	httpServer  *http.Server
@@ -230,6 +233,10 @@ func (s *Rest) routes() chi.Router {
 				rrss.Get("/site", s.rssRest.siteCommentsCtrl)
 				rrss.Get("/reply", s.rssRest.repliesCtrl)
 			})
+
+			ropen.Route("/stream", func(rstream chi.Router) {
+				rstream.Get("/info", s.pubRest.infoStreamCtrl)
+			})
 		})
 
 		// open routes, cached
@@ -314,6 +321,8 @@ func (s *Rest) controllerGroups() (public, private, admin, rss) {
 		commentFormatter: s.CommentFormatter,
 		readOnlyAge:      s.ReadOnlyAge,
 		webRoot:          s.WebRoot,
+		streamTimeOut:    s.StreamTimeOut,
+		streamRefresh:    s.StreamRefresh,
 	}
 
 	privGrp := private{

--- a/backend/app/rest/api/rest.go
+++ b/backend/app/rest/api/rest.go
@@ -171,7 +171,6 @@ func (s *Rest) makeHTTPServer(port int, router http.Handler) *http.Server {
 func (s *Rest) routes() chi.Router {
 	router := chi.NewRouter()
 	router.Use(middleware.RealIP, R.Recoverer(log.Default()))
-	router.Use(middleware.Throttle(1000))
 	router.Use(R.AppInfo("remark42", "umputun", s.Version), R.Ping)
 
 	s.pubRest, s.privRest, s.adminRest, s.rssRest = s.controllerGroups() // assign controllers for groups
@@ -192,13 +191,13 @@ func (s *Rest) routes() chi.Router {
 	authHandler, avatarHandler := s.Authenticator.Handlers()
 
 	router.Group(func(r chi.Router) {
-		r.Use(middleware.Timeout(5 * time.Second))
+		r.Use(middleware.Timeout(5*time.Second), middleware.Throttle(100))
 		r.Use(logInfoWithBody, tollbooth_chi.LimitHandler(tollbooth.NewLimiter(5, nil)), middleware.NoCache)
 		r.Mount("/auth", authHandler)
 	})
 
 	router.Group(func(r chi.Router) {
-		r.Use(middleware.Timeout(5 * time.Second))
+		r.Use(middleware.Timeout(5*time.Second), middleware.Throttle(1000))
 		r.Use(tollbooth_chi.LimitHandler(tollbooth.NewLimiter(100, nil)), middleware.NoCache)
 		r.Mount("/avatar", avatarHandler)
 	})
@@ -209,7 +208,7 @@ func (s *Rest) routes() chi.Router {
 	router.Route("/api/v1", func(rapi chi.Router) {
 
 		rapi.Group(func(rava chi.Router) {
-			rava.Use(middleware.Timeout(5 * time.Second))
+			rava.Use(middleware.Timeout(5*time.Second), middleware.Throttle(1000))
 			rava.Use(tollbooth_chi.LimitHandler(tollbooth.NewLimiter(100, nil)))
 			rava.Use(middleware.NoCache)
 			rava.Mount("/avatar", avatarHandler)
@@ -217,7 +216,7 @@ func (s *Rest) routes() chi.Router {
 
 		// open routes
 		rapi.Group(func(ropen chi.Router) {
-			ropen.Use(middleware.Timeout(30 * time.Second))
+			ropen.Use(middleware.Timeout(30*time.Second), middleware.Throttle(1000))
 			ropen.Use(tollbooth_chi.LimitHandler(tollbooth.NewLimiter(10, nil)))
 			ropen.Use(authMiddleware.Trace, middleware.NoCache, logInfoWithBody)
 			ropen.Get("/config", s.configCtrl)
@@ -242,14 +241,14 @@ func (s *Rest) routes() chi.Router {
 
 		// open routes, streams, no send timeout
 		rapi.Route("/stream", func(rstream chi.Router) {
-			rstream.Use(tollbooth_chi.LimitHandler(tollbooth.NewLimiter(10, nil)))
+			rstream.Use(tollbooth_chi.LimitHandler(tollbooth.NewLimiter(10, nil)), middleware.Throttle(500))
 			rstream.Use(authMiddleware.Trace, middleware.NoCache, logInfoWithBody)
 			rstream.Get("/info", s.pubRest.infoStreamCtrl)
 		})
 
 		// open routes, cached
 		rapi.Group(func(ropen chi.Router) {
-			ropen.Use(middleware.Timeout(30 * time.Second))
+			ropen.Use(middleware.Timeout(30*time.Second), middleware.Throttle(1000))
 			ropen.Use(tollbooth_chi.LimitHandler(tollbooth.NewLimiter(10, nil)))
 			ropen.Use(authMiddleware.Trace, logInfoWithBody)
 			ropen.Get("/picture/{user}/{id}", s.pubRest.loadPictureCtrl)
@@ -257,7 +256,7 @@ func (s *Rest) routes() chi.Router {
 
 		// protected routes, require auth
 		rapi.Group(func(rauth chi.Router) {
-			rauth.Use(middleware.Timeout(30 * time.Second))
+			rauth.Use(middleware.Timeout(30*time.Second), middleware.Throttle(1000))
 			rauth.Use(tollbooth_chi.LimitHandler(tollbooth.NewLimiter(10, nil)))
 			rauth.Use(authMiddleware.Auth, middleware.NoCache, logInfoWithBody)
 			rauth.Get("/user", s.privRest.userInfoCtrl)
@@ -266,7 +265,7 @@ func (s *Rest) routes() chi.Router {
 
 		// admin routes, require auth and admin users only
 		rapi.Route("/admin", func(radmin chi.Router) {
-			radmin.Use(middleware.Timeout(30 * time.Second))
+			radmin.Use(middleware.Timeout(30*time.Second), middleware.Throttle(100))
 			radmin.Use(tollbooth_chi.LimitHandler(tollbooth.NewLimiter(10, nil)))
 			radmin.Use(authMiddleware.Auth, authMiddleware.AdminOnly)
 			radmin.Use(middleware.NoCache, logInfoWithBody)
@@ -291,7 +290,7 @@ func (s *Rest) routes() chi.Router {
 
 		// protected routes, throttled to 10/s by default, controlled by external UpdateLimiter param
 		rapi.Group(func(rauth chi.Router) {
-			rauth.Use(middleware.Timeout(10 * time.Second))
+			rauth.Use(middleware.Timeout(10*time.Second), middleware.Throttle(1000))
 			rauth.Use(tollbooth_chi.LimitHandler(tollbooth.NewLimiter(s.updateLimiter(), nil)))
 			rauth.Use(authMiddleware.Auth)
 			rauth.Use(middleware.NoCache)
@@ -305,7 +304,7 @@ func (s *Rest) routes() chi.Router {
 
 		// protected routes, anonymous rejected
 		rapi.Group(func(rauth chi.Router) {
-			rauth.Use(middleware.Timeout(10 * time.Second))
+			rauth.Use(middleware.Timeout(10*time.Second), middleware.Throttle(1000))
 			rauth.Use(tollbooth_chi.LimitHandler(tollbooth.NewLimiter(s.updateLimiter(), nil)))
 			rauth.Use(authMiddleware.Auth, rejectAnonUser)
 			rauth.Use(logger.New(logger.Log(log.Default()), logger.Prefix("[DEBUG]"), logger.IPfn(ipFn)).Handler)
@@ -316,7 +315,7 @@ func (s *Rest) routes() chi.Router {
 
 	// open routes on root level
 	router.Group(func(rroot chi.Router) {
-		rroot.Use(middleware.Timeout(10 * time.Second))
+		rroot.Use(middleware.Timeout(10*time.Second), middleware.Throttle(100))
 		rroot.Use(tollbooth_chi.LimitHandler(tollbooth.NewLimiter(50, nil)))
 		rroot.Get("/index.html", s.pubRest.getStartedCtrl)
 		rroot.Get("/robots.txt", s.pubRest.robotsCtrl)

--- a/backend/app/rest/api/rest_public.go
+++ b/backend/app/rest/api/rest_public.go
@@ -155,15 +155,17 @@ func (s *public) infoStreamCtrl(w http.ResponseWriter, r *http.Request) {
 
 	key := cache.NewKey(locator.SiteID).ID(URLKey(r)).Scopes(locator.SiteID, locator.URL)
 	lastTS := time.Time{}
+	lastCount := 0
 	info := func() (data []byte, upd bool, err error) {
 		data, err = s.cache.Get(key, func() ([]byte, error) {
 			info, e := s.dataService.Info(locator, s.readOnlyAge)
 			if e != nil {
 				return nil, e
 			}
-			if info.LastTS != lastTS {
+			if info.LastTS != lastTS || info.Count != lastCount {
 				lastTS = info.LastTS
-				upd = true // cache update used as indication of post update. comparing lastTS for no-cache
+				lastCount = info.Count // removal won't update lastTS
+				upd = true             // cache update used as indication of post update. comparing lastTS for no-cache
 			}
 			return encodeJSONWithHTML(info)
 		})

--- a/backend/app/rest/api/rest_public.go
+++ b/backend/app/rest/api/rest_public.go
@@ -184,8 +184,10 @@ func (s *public) infoStreamCtrl(w http.ResponseWriter, r *http.Request) {
 	for {
 		select {
 		case <-r.Context().Done(): // request closed by remote client
+			log.Printf("[DEBUG] info stream closed by remote client, %v", r.Context().Err())
 			return
 		case <-ctx.Done(): // request closed by timeout
+			log.Printf("[DEBUG] info stream closed due to timeout")
 			return
 		case <-tick.C: // refresh
 			resp, upd, err := info()

--- a/backend/app/rest/api/rest_public_test.go
+++ b/backend/app/rest/api/rest_public_test.go
@@ -581,7 +581,7 @@ func TestRest_InfoStreamTimeout(t *testing.T) {
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	go func() {
-		// write 10 more comments in 10ms intervals
+		// write 10 more comments in 100ms intervals
 		for i := 0; i < 9; i++ {
 			time.Sleep(100 * time.Millisecond)
 			resp, err := post(t, ts.URL+"/api/v1/comment",


### PR DESCRIPTION
This one adds API to stream minimal updates for a given post. The goal is to provide UI with a way to subscribe to such update events and be able to refresh or notify the user (see #253)

The API is `/stream/info` and it allows smth like this:

```
curl -n "http://127.0.0.1:8080/api/v1/stream/info?site=remark&url=https://remark42.com/demo/"

{"url":"https://remark42.com/demo/","count":19,"first_time":"2018-09-02T13:27:48.680420472-05:00","last_time":"2019-05-12T13:11:50.548327608-05:00"}
{"url":"https://remark42.com/demo/","count":20,"first_time":"2018-09-02T13:27:48.680420472-05:00","last_time":"2019-06-02T15:29:27.799347624-05:00"}
{"url":"https://remark42.com/demo/","count":21,"first_time":"2018-09-02T13:27:48.680420472-05:00","last_time":"2019-06-02T15:29:50.941572771-05:00"}
{"url":"https://remark42.com/demo/","count":20,"first_time":"2018-09-02T13:27:48.680420472-05:00","last_time":"2019-06-02T15:29:50.941572771-05:00"}
...
```

_note: notification sent on the new/updated comment as well as on removed comments, so `count` may be decremented or incremented_

The stream can be terminated on timeout (no new comments for some time (currently 15 minutes) or by client-side closing the connection. The integration with frontend should start such a call on a comment page, listen to updates and reconnect as needed. It will be also nice to run on the active page only.