### PR TITLE
Fix: settings widget fails because it expects list but gets null

### DIFF
--- a/frontend/app/common/api.ts
+++ b/frontend/app/common/api.ts
@@ -220,7 +220,7 @@ export const unblockUser = (
     withCredentials: true,
   });
 
-export const getBlocked = (): Promise<BlockedUser[]> =>
+export const getBlocked = (): Promise<BlockedUser[] | null> =>
   fetcher.get({
     url: '/admin/blocked',
     withCredentials: true,

--- a/frontend/app/store/user/actions.ts
+++ b/frontend/app/store/user/actions.ts
@@ -50,7 +50,7 @@ export const logout = (): StoreAction<Promise<void>> => async dispatch => {
 };
 
 export const fetchBlockedUsers = (): StoreAction<Promise<BlockedUser[]>> => async dispatch => {
-  const list = await api.getBlocked();
+  const list = (await api.getBlocked()) || [];
   dispatch({
     type: USER_BANLIST_SET,
     list,


### PR DESCRIPTION
When user is logged in, has no blocked users, and tries to open settings widget operation fails because reducer expects array of blocked users but api (`/admin/blocked`) returns null