### PR TITLE
Fix wrong classname

### DIFF
--- a/frontend/app/components/settings/settings.tsx
+++ b/frontend/app/components/settings/settings.tsx
@@ -135,7 +135,7 @@ export default class BlockedUsers extends Component<Props, State> {
                       </span>
                       <span className="settings__blocked-users-user-block-ttl"> {formatTime(new Date(user.time))}</span>
                       {isUserUnblocked && (
-                        <span {...getHandleClickProps(() => this.block(user))} className="blocked-users__action">
+                        <span {...getHandleClickProps(() => this.block(user))} className="settings__action">
                           block
                         </span>
                       )}


### PR DESCRIPTION
wrong className leads to unstyled button in settings
before:
![Screenshot 2019-07-16 at 03 22 33](https://user-images.githubusercontent.com/884649/61257412-95f12100-a779-11e9-8e08-324b555da10e.png)
after:
![Screenshot 2019-07-16 at 03 23 24](https://user-images.githubusercontent.com/884649/61257416-98ec1180-a779-11e9-8500-afd41eebc03a.png)

