### PR TITLE
Fix sort been stalled

### DIFF
--- a/frontend/app/store/sort/actions.ts
+++ b/frontend/app/store/sort/actions.ts
@@ -8,7 +8,7 @@ import { SORT_SET, SORT_SET_ACTION } from './types';
 
 function setSortCookie(sort: Sorting) {
   try {
-    setCookie(COOKIE_SORT_KEY, sort, { expires: 60 * 60 * 24 * 365 }); // save sorting for a year
+    setCookie(COOKIE_SORT_KEY, sort, { expires: 60 * 60 * 24 * 365, path: '/' }); // save sorting for a year
   } catch {
     // can't save; ignore it
   }


### PR DESCRIPTION
Sorting change appears broken because cookie path being set for "/web" but after refresh takes value from cookie with path `/web/`.