### PR TITLE
Fix blocking

### DIFF
--- a/frontend/app/components/comment/comment.tsx
+++ b/frontend/app/components/comment/comment.tsx
@@ -454,15 +454,12 @@ export class Comment extends Component<Props, State> {
     const o = {
       ...props.data,
       controversyText: `Controversy: ${(props.data.controversy || 0).toFixed(2)}`,
-      text: !props.data.text.length
-        ? ''
-        : props.view === 'preview'
-        ? getTextSnippet(props.data.text)
-        : props.isUserBanned && !isAdmin
-        ? 'This user was blocked'
-        : props.data.delete
-        ? 'This comment was deleted'
-        : props.data.text,
+      text:
+        props.view === 'preview'
+          ? getTextSnippet(props.data.text)
+          : props.data.delete
+          ? 'This comment was deleted'
+          : props.data.text,
       time: formatTime(new Date(props.data.time)),
       orig: isEditing
         ? props.data.orig &&
@@ -587,7 +584,7 @@ export class Comment extends Component<Props, State> {
               </a>
             )}
 
-            {isAdmin && props.isUserBanned && props.view !== 'user' && <span className="comment__status">Blocked</span>}
+            {props.isUserBanned && props.view !== 'user' && <span className="comment__status">Blocked</span>}
 
             {isAdmin && !props.isUserBanned && props.data.delete && <span className="comment__status">Deleted</span>}
 

--- a/frontend/app/components/comment/comment.tsx
+++ b/frontend/app/components/comment/comment.tsx
@@ -454,11 +454,11 @@ export class Comment extends Component<Props, State> {
     const o = {
       ...props.data,
       controversyText: `Controversy: ${(props.data.controversy || 0).toFixed(2)}`,
-      text: props.data.text.length
-        ? props.view === 'preview'
-          ? getTextSnippet(props.data.text)
-          : props.data.text
-        : this.props.isUserBanned
+      text: !props.data.text.length
+        ? ''
+        : props.view === 'preview'
+        ? getTextSnippet(props.data.text)
+        : props.isUserBanned && !isAdmin
         ? 'This user was blocked'
         : props.data.delete
         ? 'This comment was deleted'

--- a/frontend/app/components/comment/connected-comment.ts
+++ b/frontend/app/components/comment/connected-comment.ts
@@ -40,7 +40,7 @@ const mapStateToProps = (state: StoreState, cprops: { data: CommentType }) => {
   > = {
     editMode: getCommentMode(state, cprops.data.id),
     user: state.user,
-    isUserBanned: state.bannedUsers.find(u => u.id === cprops.data.user.id) !== undefined,
+    isUserBanned: cprops.data.user.block || state.bannedUsers.find(u => u.id === cprops.data.user.id) !== undefined,
     post_info: state.info,
     isCommentsDisabled: state.info.read_only || false,
     theme: state.theme,


### PR DESCRIPTION
To https://github.com/umputun/remark/issues/377#issuecomment-513491892

Now blocked comments rendered like on screenshot below, no matter whether user is admin or not:
![Screenshot 2019-07-23 at 02 15 29](https://user-images.githubusercontent.com/884649/61671334-c6900800-acef-11e9-98f6-8d426a461a6d.png)

One thing I'm not sure is that if user was blocked permanently his comment (if it has childs) will be rendered like this:
![Screenshot 2019-07-23 at 02 16 47](https://user-images.githubusercontent.com/884649/61671390-1969bf80-acf0-11e9-99a1-837d2070c697.png)
... so user traces still present. @umputun if you think this is undesired, I can tell that I'm actually cannot differentiate if user was blocked permanently or not on front, so to render such comment differently (ghosted avatar and so on) I need another one field in User struct.

