### PR TITLE
Allow ID of container node to optionally be provided in comments widget config

### DIFF
--- a/frontend/app/common/config-types.ts
+++ b/frontend/app/common/config-types.ts
@@ -15,6 +15,7 @@ export interface CommentsConfig {
   max_shown_comments?: number;
   theme?: Theme;
   page_title?: string;
+  node?: string;
 }
 
 export interface LastCommentsConfig {

--- a/frontend/app/embed.ts
+++ b/frontend/app/embed.ts
@@ -19,7 +19,7 @@ async function init(): Promise<void> {
   __webpack_public_path__ = HOST + '/web/';
   await loadPolyfills();
 
-  const node = document.getElementById(NODE_ID);
+  const node = document.getElementById( remark_config.node || NODE_ID);
 
   if (!node) {
     console.error("Remark42: Can't find root node.");

--- a/frontend/app/embed.ts
+++ b/frontend/app/embed.ts
@@ -19,7 +19,7 @@ async function init(): Promise<void> {
   __webpack_public_path__ = HOST + '/web/';
   await loadPolyfills();
 
-  const node = document.getElementById( remark_config.node || NODE_ID);
+  const node = document.getElementById(remark_config.node || NODE_ID);
 
   if (!node) {
     console.error("Remark42: Can't find root node.");


### PR DESCRIPTION
This might not be essential for many people but it seems like a simple change and it seems sensible to allow people to change it; e.g. to follow their desired naming conventions.

This also introduces the additional possibility of having multiple sets of comments on one page (as long as different URL values are provided) – I want to use remark on a site for online consultation, with users able to comment on multiple sections of a proposal.

If there are repercussions of this change I've missed then apologies!