### PR TITLE
Fixing indent in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -633,7 +633,7 @@ Sort can be `time`, `active` or `score`. Supported sort order with prefix -/+, i
 
   ```go
   type Config struct {
-     	Version        string   `json:"version"`
+        Version        string   `json:"version"`
         EditDuration   int      `json:"edit_duration"`
         MaxCommentSize int      `json:"max_comment_size"`
         Admins         []string `json:"admins"`


### PR DESCRIPTION
Here is the screenshot of rendered README.md on https://github.com/umputun/remark :

![Screenshot 2019-08-11 at 23 32 01](https://user-images.githubusercontent.com/47263/62839251-57735700-bc90-11e9-96fb-3da059b6741a.png)

After this change `Version` will be alinged.