### PR TITLE
Change coveralls to use build-in GITHUB_TOKEN

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -53,9 +53,9 @@ jobs:
       run: |
         export GIT_BRANCH=$GITHUB_REF
         cd backend
-        $(go env GOPATH)/bin/goveralls -service="github" -coverprofile=$GITHUB_WORKSPACE/profile.cov -repotoken $GITHUB_TOKEN
+        $(go env GOPATH)/bin/goveralls -service="github" -coverprofile=$GITHUB_WORKSPACE/profile.cov
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: build docker image
       run: docker build --build-arg SKIP_BACKEND_TEST=true --build-arg CI=github .

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -55,9 +55,9 @@ jobs:
 
         cd backend
         env
-        $(go env GOPATH)/bin/goveralls -service="GitHub Action" -coverprofile=$GITHUB_WORKSPACE/profile.cov -repotoken $GITHUB_TOKEN
+        $(go env GOPATH)/bin/goveralls -service="github" -coverprofile=$GITHUB_WORKSPACE/profile.cov -repotoken $GITHUB_TOKEN
       env:
-        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: build docker image
       run: docker build --build-arg SKIP_BACKEND_TEST=true --build-arg CI=github .

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -59,9 +59,9 @@ jobs:
         fi
 
         cd backend
-        $(go env GOPATH)/bin/goveralls -service="GitHub Action" -coverprofile=$GITHUB_WORKSPACE/profile.cov -repotoken $COVERALLS_TOKEN
+        $(go env GOPATH)/bin/goveralls -service="GitHub Action" -coverprofile=$GITHUB_WORKSPACE/profile.cov -repotoken $GITHUB_TOKEN
       env:
-        COVERALLS_TOKEN: ${{secrets.COVERALLS_TOKEN}}
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
     - name: build docker image
       run: docker build --build-arg SKIP_BACKEND_TEST=true --build-arg CI=github .

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -52,9 +52,7 @@ jobs:
     - name: submit coverage
       run: |
         export GIT_BRANCH=$GITHUB_REF
-
         cd backend
-        env
         $(go env GOPATH)/bin/goveralls -service="github" -coverprofile=$GITHUB_WORKSPACE/profile.cov -repotoken $GITHUB_TOKEN
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -51,12 +51,7 @@ jobs:
 
     - name: submit coverage
       run: |
-        export GIT_BRANCH="${GITHUB_REF/refs\/heads\//}"
-        export GIT_TAG="${GITHUB_REF/refs\/tags\//}"
-
-        if [[ "$GIT_TAG" != "$GITHUB_REF" ]]; then
-          export GIT_BRANCH=$GIT_TAG
-        fi
+        export GIT_BRANCH=$GITHUB_REF
 
         cd backend
         $(go env GOPATH)/bin/goveralls -service="GitHub Action" -coverprofile=$GITHUB_WORKSPACE/profile.cov -repotoken $GITHUB_TOKEN

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -54,6 +54,7 @@ jobs:
         export GIT_BRANCH=$GITHUB_REF
 
         cd backend
+        env
         $(go env GOPATH)/bin/goveralls -service="GitHub Action" -coverprofile=$GITHUB_WORKSPACE/profile.cov -repotoken $GITHUB_TOKEN
       env:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Attempt to fix #462 using [GITHUB_TOKEN](https://help.github.com/en/github/automating-your-workflow-with-github-actions/authenticating-with-the-github_token#about-the-github_token-secret) which is not a standard secret and would work in forks.