### PR TITLE
User details custom storage implementation example

### DIFF
--- a/backend/_example/memory_store/accessor/data_test.go
+++ b/backend/_example/memory_store/accessor/data_test.go
@@ -555,6 +555,51 @@ func TestMem_FlagListBlocked(t *testing.T) {
 	assert.Equal(t, 0, len(vv))
 }
 
+func TestMem_UserDetail(t *testing.T) {
+
+	b := prepMem(t)
+
+	for _, detail := range []engine.UserDetail{engine.Email} {
+		readDetail := func(site, user string) string {
+			req := engine.UserDetailRequest{Detail: detail, Locator: store.Locator{SiteID: site}, UserID: user}
+			v, err := b.UserDetail(req)
+			require.NoError(t, err)
+			return v
+		}
+
+		setDetail := func(site, user string, value string, delete bool) error {
+			req := engine.UserDetailRequest{Detail: detail, Locator: store.Locator{SiteID: site}, UserID: user, Update: value, Delete: delete}
+			_, err := b.UserDetail(req)
+			return err
+		}
+
+		assert.Equal(t, "", readDetail("radio-t", "u1"), "no %s set yet", detail)
+
+		assert.NoError(t, setDetail("radio-t", "u1", "value1", false))
+		assert.Equal(t, "value1", readDetail("radio-t", "u1"), "u1 %s set", detail)
+		assert.NoError(t, setDetail("radio-t", "u1", "value2", false))
+		assert.Equal(t, "value2", readDetail("radio-t", "u1"), "u1 %s updated", detail)
+
+		assert.Equal(t, "", readDetail("radio-t", "u2"), "u2 still don't have %s set", detail)
+		assert.NoError(t, setDetail("radio-t", "u1", "", true))
+		assert.Equal(t, "", readDetail("radio-t", "u1"), "u1 %s is not set anymore", detail)
+
+		assert.NoError(t, setDetail("radio-t", "u1xyz", "", true))
+
+		assert.Equal(t, "", readDetail("radio-t-bad", "u1"), "nothing verified on wrong site")
+
+		assert.NoError(t, setDetail("radio-t", "u1", "value3", false))
+		assert.EqualError(t, setDetail("radio-t", "u2", "value4", true), "Both Delete and Update are set, pick one")
+		assert.NoError(t, setDetail("radio-t", "u3", "", false))
+	}
+	v, err := b.UserDetail(engine.UserDetailRequest{Update: "new_value"})
+	require.EqualError(t, err, "UserID is not set")
+	require.Equal(t, "", v)
+	v, err = b.UserDetail(engine.UserDetailRequest{})
+	require.NoError(t, err, "Unset UserID results in empty response")
+	require.Equal(t, "", v)
+}
+
 func TestMem_DeleteComment(t *testing.T) {
 
 	b := prepMem(t)

--- a/backend/_example/memory_store/server/rpc.go
+++ b/backend/_example/memory_store/server/rpc.go
@@ -28,16 +28,17 @@ func NewRPC(e engine.Interface, a admin.Store, r *jrpc.Server) *RPC {
 func (s *RPC) addHandlers() {
 	// data store handlers
 	s.Group("store", jrpc.HandlersGroup{
-		"create":     s.createHndl,
-		"find":       s.findHndl,
-		"get":        s.getHndl,
-		"update":     s.updateHndl,
-		"count":      s.countHndl,
-		"info":       s.infoHndl,
-		"flag":       s.flagHndl,
-		"list_flags": s.listFlagsHndl,
-		"delete":     s.deleteHndl,
-		"close":      s.closeHndl,
+		"create":           s.createHndl,
+		"find":             s.findHndl,
+		"get":              s.getHndl,
+		"update":           s.updateHndl,
+		"count":            s.countHndl,
+		"info":             s.infoHndl,
+		"flag":             s.flagHndl,
+		"list_flags":       s.listFlagsHndl,
+		"user_detail":      s.userDetailHndl,
+		"delete":           s.deleteHndl,
+		"close":            s.closeHndl,
 	})
 
 	// admin store handlers
@@ -127,6 +128,16 @@ func (s *RPC) listFlagsHndl(id uint64, params json.RawMessage) (rr jrpc.Response
 	}
 	flags, err := s.eng.ListFlags(req)
 	return jrpc.EncodeResponse(id, flags, err)
+}
+
+// userDetailHndl get and sets detail value
+func (s *RPC) userDetailHndl(id uint64, params json.RawMessage) (rr jrpc.Response) {
+	req := engine.UserDetailRequest{}
+	if err := json.Unmarshal(params, &req); err != nil {
+		return jrpc.Response{Error: err.Error()}
+	}
+	value, err := s.eng.UserDetail(req)
+	return jrpc.EncodeResponse(id, value, err)
 }
 
 // deleteHndl remove comment(s)


### PR DESCRIPTION
This PR is part of solution #265 and the effort of splitting #438 into smaller chunks.

It implements a custom storage example for UserDetails, which is supposed to be added to remark in #469. Same as mentioned PR, it supports storing any strings but not slices of strings.