### PR TITLE
docker-compose format and comment fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -591,7 +591,7 @@ Developer build running by `webpack-dev-server` supports devtools for [React](ht
 
 #### Frontend guide
 
-Frontend guide can be found here: [./frontend/README.md](./frontend/README.md)
+Frontend guide can be found here: [./frontend/Readme.md](./frontend/Readme.md)
 
 ## API
 

--- a/compose-dev-backend.yml
+++ b/compose-dev-backend.yml
@@ -1,15 +1,10 @@
 # compose file for local development
-# starts backend on 8080 with basic auth "dev:password" and Dev oauth2 provider on port 8084, UI on http://127.0.0.1:8080/web
+# starts backend on 8080 with basic auth "dev:password" and Dev oauth2 provider on port 8084
+# UI on http://127.0.0.1:8080/web
 #
-# mongo-related tests needs mongodb container running - docker run -d -name=mongo mongo:3.6 --smallfiles
-# start build with backend tests:
-# MONGO_REMARK_TEST=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' mongo) \
-#  docker-compose -f compose-dev-backend.yml build
-#
-# to skip mongo test set MONGO_REMARK_TEST=skip
-#
+# build remark42 docker image - docker-compose -f compose-dev-backend.yml build
 # start remark42 service - docker-compose -f compose-dev-backend.yml up
-version: "2"
+version: '2'
 
 services:
     remark42:

--- a/compose-dev-frontend.yml
+++ b/compose-dev-frontend.yml
@@ -1,7 +1,9 @@
 # compose file for local development
 # starts backend on 8080 with basic auth "dev:password" and Dev oauth2 provider on port 8084
-# UI on https://127.0.0.1:8080/web
-
+# UI on http://127.0.0.1:8080/web
+#
+# build remark42 docker image - docker-compose -f compose-dev-frontend.yml build
+# start remark42 service - docker-compose -f compose-dev-frontend.yml up
 version: '2'
 
 services:
@@ -18,14 +20,14 @@ services:
         hostname: "remark42-dev"
 
         logging:
-          driver: json-file
-          options:
-              max-size: "10m"
-              max-file: "5"
+            driver: json-file
+            options:
+                max-size: "10m"
+                max-file: "5"
 
         ports:
-         - "8080:8080" # primary rest server
-         - "8084:8084" # local oauth2 server
+            - "8080:8080" # primary rest server
+            - "8084:8084" # local oauth2 server
 
         environment:
             - REMARK_URL=http://127.0.0.1:8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,10 +9,10 @@ services:
         restart: always
 
         logging:
-          driver: json-file
-          options:
-              max-size: "10m"
-              max-file: "5"
+            driver: json-file
+            options:
+                max-size: "10m"
+                max-file: "5"
 
         # uncomment to expose directly (no proxy)
         #ports:

--- a/frontend/Readme.md
+++ b/frontend/Readme.md
@@ -30,4 +30,4 @@
 
 ### Notes
 
-* Frontend part being bundled on docker env gets placed on `/src/web` and is available via `http://{host}/web`. for example `embed.js` entry point will be availabale at `http://{host}/web/embed.js`
+* Frontend part being bundled on docker env gets placed on `/src/web` and is available via `http://{host}/web`. for example `embed.js` entry point will be available at `http://{host}/web/embed.js`


### PR DESCRIPTION
- format all docker-compose files with the same settings (indent 4)
- remove outdated mongo reference from backend docker-compose comments
- unify comment format at the beginning of frontend and backend  docker-compose
- fix reference to frontend readme file to proper case
- fix single typo in frontend readme