### PR TITLE
Move email unsubscription endpoint outside of API and make it HTML

### DIFF
--- a/backend/app/cmd/server.go
+++ b/backend/app/cmd/server.go
@@ -700,7 +700,7 @@ func (s *ServerCommand) makeNotify(dataStore *service.DataStore, authenticator *
 			emailParams := notify.EmailParams{
 				From:                s.Notify.Email.From,
 				VerificationSubject: s.Notify.Email.VerificationSubject,
-				UnsubscribeURL:      s.RemarkURL + "/api/v1/email/unsubscribe",
+				UnsubscribeURL:      s.RemarkURL + "/email/unsubscribe.html",
 				TokenGenFn: func(userID, email, site string) (string, error) {
 					claims := token.Claims{
 						Handshake: &token.Handshake{ID: userID + "::" + email},

--- a/backend/app/rest/api/rest.go
+++ b/backend/app/rest/api/rest.go
@@ -235,8 +235,6 @@ func (s *Rest) routes() chi.Router {
 			ropen.Get("/list", s.pubRest.listCtrl)
 			ropen.Post("/preview", s.pubRest.previewCommentCtrl)
 			ropen.Get("/info", s.pubRest.infoCtrl)
-			ropen.Get("/email/unsubscribe", s.privRest.emailUnsubscribeCtrl)
-			ropen.Post("/email/unsubscribe", s.privRest.emailUnsubscribeCtrl)
 			ropen.Get("/img", s.ImageProxy.Handler)
 
 			ropen.Route("/rss", func(rrss chi.Router) {
@@ -333,6 +331,8 @@ func (s *Rest) routes() chi.Router {
 		rroot.Use(tollbooth_chi.LimitHandler(tollbooth.NewLimiter(50, nil)))
 		rroot.Get("/index.html", s.pubRest.getStartedCtrl)
 		rroot.Get("/robots.txt", s.pubRest.robotsCtrl)
+		rroot.Get("/email/unsubscribe.html", s.privRest.emailUnsubscribeCtrl)
+		rroot.Post("/email/unsubscribe.html", s.privRest.emailUnsubscribeCtrl)
 	})
 
 	// file server for static content from /web

--- a/backend/app/rest/api/rest_private.go
+++ b/backend/app/rest/api/rest_private.go
@@ -65,11 +65,7 @@ const unsubscribeHtml = `<!DOCTYPE html>
 <body>
 <div style="text-align: center; font-family: Arial, sans-serif; font-size: 18px;">
     <h1 style="position: relative; color: #4fbbd6; margin-top: 0.2em;">Remark42</h1>
-    {{if .Error}}
-        <p style="position: relative; max-width: 20em; margin: 0 auto 1em auto; line-height: 1.4em;">{{.Error}}: {{.Details}}.</p>
-    {{else}}
-        <p style="position: relative; max-width: 20em; margin: 0 auto 1em auto; line-height: 1.4em;">Successfully unsubscribed</p>
-    {{end}}
+	<p style="position: relative; max-width: 20em; margin: 0 auto 1em auto; line-height: 1.4em;">Successfully unsubscribed</p>
 </div>
 </body>
 </html>
@@ -361,28 +357,27 @@ func (s *private) setConfirmedEmailCtrl(w http.ResponseWriter, r *http.Request) 
 
 // POST/GET /email/unsubscribe.html?site=siteID&tkn=jwt - unsubscribe the user in token from email notifications
 func (s *private) emailUnsubscribeCtrl(w http.ResponseWriter, r *http.Request) {
-	answerHtml := template.Must(template.New("unsubscribe").Parse(unsubscribeHtml))
 	tkn := r.URL.Query().Get("tkn")
 	if tkn == "" {
-		rest.SendErrorHTML(w, r, answerHtml, http.StatusBadRequest, errors.New("missing parameter"), "token parameter is required", rest.ErrInternal)
+		rest.SendErrorHTML(w, r, http.StatusBadRequest, errors.New("missing parameter"), "token parameter is required", rest.ErrInternal)
 		return
 	}
 	locator := store.Locator{SiteID: r.URL.Query().Get("site")}
 
 	confClaims, err := s.authenticator.TokenService().Parse(tkn)
 	if err != nil {
-		rest.SendErrorHTML(w, r, answerHtml, http.StatusForbidden, err, "failed to verify confirmation token", rest.ErrInternal)
+		rest.SendErrorHTML(w, r, http.StatusForbidden, err, "failed to verify confirmation token", rest.ErrInternal)
 		return
 	}
 
 	if s.authenticator.TokenService().IsExpired(confClaims) {
-		rest.SendErrorHTML(w, r, answerHtml, http.StatusForbidden, errors.New("expired"), "failed to verify confirmation token", rest.ErrInternal)
+		rest.SendErrorHTML(w, r, http.StatusForbidden, errors.New("expired"), "failed to verify confirmation token", rest.ErrInternal)
 		return
 	}
 
 	elems := strings.Split(confClaims.Handshake.ID, "::")
 	if len(elems) != 2 {
-		rest.SendErrorHTML(w, r, answerHtml, http.StatusBadRequest, errors.New(confClaims.Handshake.ID), "invalid handshake token", rest.ErrInternal)
+		rest.SendErrorHTML(w, r, http.StatusBadRequest, errors.New(confClaims.Handshake.ID), "invalid handshake token", rest.ErrInternal)
 		return
 	}
 	userID := elems[0]
@@ -393,11 +388,11 @@ func (s *private) emailUnsubscribeCtrl(w http.ResponseWriter, r *http.Request) {
 		log.Printf("[WARN] can't read email for %s, %v", userID, err)
 	}
 	if existingAddress == "" {
-		rest.SendErrorHTML(w, r, answerHtml, http.StatusConflict, errors.New("user is not subscribed"), "user does not have active email subscription", rest.ErrInternal)
+		rest.SendErrorHTML(w, r, http.StatusConflict, errors.New("user is not subscribed"), "user does not have active email subscription", rest.ErrInternal)
 		return
 	}
 	if address != existingAddress {
-		rest.SendErrorHTML(w, r, answerHtml, http.StatusBadRequest, errors.New("wrong email unsubscription"), "email address in request does not match known for this user", rest.ErrInternal)
+		rest.SendErrorHTML(w, r, http.StatusBadRequest, errors.New("wrong email unsubscription"), "email address in request does not match known for this user", rest.ErrInternal)
 		return
 	}
 
@@ -405,7 +400,7 @@ func (s *private) emailUnsubscribeCtrl(w http.ResponseWriter, r *http.Request) {
 
 	if err := s.dataService.DeleteUserDetail(locator, userID, engine.UserEmail); err != nil {
 		code := parseError(err, rest.ErrInternal)
-		rest.SendErrorHTML(w, r, answerHtml, http.StatusBadRequest, err, "can't delete email for user", code)
+		rest.SendErrorHTML(w, r, http.StatusBadRequest, err, "can't delete email for user", code)
 		return
 	}
 	// clean User.Email from the token, if user has the token
@@ -416,13 +411,14 @@ func (s *private) emailUnsubscribeCtrl(w http.ResponseWriter, r *http.Request) {
 	if claims.User != nil && claims.User.Email != "" {
 		claims.User.Email = ""
 		if _, err = s.authenticator.TokenService().Set(w, claims); err != nil {
-			rest.SendErrorHTML(w, r, answerHtml, http.StatusInternalServerError, err, "failed to set token", rest.ErrInternal)
+			rest.SendErrorHTML(w, r, http.StatusInternalServerError, err, "failed to set token", rest.ErrInternal)
 			return
 		}
 	}
 
+	tmpl := template.Must(template.New("unsubscribe").Parse(unsubscribeHtml))
 	msg := bytes.Buffer{}
-	err = answerHtml.Execute(&msg, rest.ErrTmplData{})
+	err = tmpl.Execute(&msg, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/backend/app/rest/api/rest_private.go
+++ b/backend/app/rest/api/rest_private.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"html/template"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -416,12 +417,16 @@ func (s *private) emailUnsubscribeCtrl(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// MustExecute behaves like template.Execute, but panics if an error occurs.
+	MustExecute := func(tmpl *template.Template, wr io.Writer, data interface{}) {
+		if err := tmpl.Execute(wr, data); err != nil {
+			panic(err)
+		}
+	}
+
 	tmpl := template.Must(template.New("unsubscribe").Parse(unsubscribeHtml))
 	msg := bytes.Buffer{}
-	err = tmpl.Execute(&msg, nil)
-	if err != nil {
-		panic(err)
-	}
+	MustExecute(tmpl, &msg, nil)
 	render.HTML(w, r, msg.String())
 }
 

--- a/backend/app/rest/api/rest_private.go
+++ b/backend/app/rest/api/rest_private.go
@@ -1,10 +1,12 @@
 package api
 
 import (
+	"bytes"
 	"compress/gzip"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"html/template"
 	"net/http"
 	"strings"
 	"time"
@@ -53,6 +55,25 @@ type privStore interface {
 	IsBlocked(siteID string, userID string) bool
 	Info(locator store.Locator, readonlyAge int) (store.PostInfo, error)
 }
+
+const unsubscribeHtml = `<!DOCTYPE html>
+<html>
+<head>
+    <meta name="viewport" content="width=device-width"/>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+</head>
+<body>
+<div style="text-align: center; font-family: Arial, sans-serif; font-size: 18px;">
+    <h1 style="position: relative; color: #4fbbd6; margin-top: 0.2em;">Remark42</h1>
+    {{if .Error}}
+        <p style="position: relative; max-width: 20em; margin: 0 auto 1em auto; line-height: 1.4em;">{{.Error}}: {{.Details}}.</p>
+    {{else}}
+        <p style="position: relative; max-width: 20em; margin: 0 auto 1em auto; line-height: 1.4em;">Successfully unsubscribed</p>
+    {{end}}
+</div>
+</body>
+</html>
+`
 
 // POST /comment - adds comment, resets all immutable fields
 func (s *private) createCommentCtrl(w http.ResponseWriter, r *http.Request) {
@@ -338,29 +359,30 @@ func (s *private) setConfirmedEmailCtrl(w http.ResponseWriter, r *http.Request) 
 	render.JSON(w, r, R.JSON{"updated": true, "address": val})
 }
 
-// POST/GET /email/unsubscribe?site=siteID&tkn=jwt - unsubscribe the user in token from email notifications
+// POST/GET /email/unsubscribe.html?site=siteID&tkn=jwt - unsubscribe the user in token from email notifications
 func (s *private) emailUnsubscribeCtrl(w http.ResponseWriter, r *http.Request) {
+	answerHtml := template.Must(template.New("unsubscribe").Parse(unsubscribeHtml))
 	tkn := r.URL.Query().Get("tkn")
 	if tkn == "" {
-		rest.SendErrorJSON(w, r, http.StatusBadRequest, errors.New("missing parameter"), "token parameter is required", rest.ErrInternal)
+		rest.SendErrorHTML(w, r, answerHtml, http.StatusBadRequest, errors.New("missing parameter"), "token parameter is required", rest.ErrInternal)
 		return
 	}
 	locator := store.Locator{SiteID: r.URL.Query().Get("site")}
 
 	confClaims, err := s.authenticator.TokenService().Parse(tkn)
 	if err != nil {
-		rest.SendErrorJSON(w, r, http.StatusForbidden, err, "failed to verify confirmation token", rest.ErrInternal)
+		rest.SendErrorHTML(w, r, answerHtml, http.StatusForbidden, err, "failed to verify confirmation token", rest.ErrInternal)
 		return
 	}
 
 	if s.authenticator.TokenService().IsExpired(confClaims) {
-		rest.SendErrorJSON(w, r, http.StatusForbidden, errors.New("expired"), "failed to verify confirmation token", rest.ErrInternal)
+		rest.SendErrorHTML(w, r, answerHtml, http.StatusForbidden, errors.New("expired"), "failed to verify confirmation token", rest.ErrInternal)
 		return
 	}
 
 	elems := strings.Split(confClaims.Handshake.ID, "::")
 	if len(elems) != 2 {
-		rest.SendErrorJSON(w, r, http.StatusBadRequest, errors.New(confClaims.Handshake.ID), "invalid handshake token", rest.ErrInternal)
+		rest.SendErrorHTML(w, r, answerHtml, http.StatusBadRequest, errors.New(confClaims.Handshake.ID), "invalid handshake token", rest.ErrInternal)
 		return
 	}
 	userID := elems[0]
@@ -371,11 +393,11 @@ func (s *private) emailUnsubscribeCtrl(w http.ResponseWriter, r *http.Request) {
 		log.Printf("[WARN] can't read email for %s, %v", userID, err)
 	}
 	if existingAddress == "" {
-		rest.SendErrorJSON(w, r, http.StatusConflict, errors.New("user is not subscribed"), "user does not have active email subscription", rest.ErrInternal)
+		rest.SendErrorHTML(w, r, answerHtml, http.StatusConflict, errors.New("user is not subscribed"), "user does not have active email subscription", rest.ErrInternal)
 		return
 	}
 	if address != existingAddress {
-		rest.SendErrorJSON(w, r, http.StatusBadRequest, errors.New("wrong email unsubscription"), "email address in request does not match known for this user", rest.ErrInternal)
+		rest.SendErrorHTML(w, r, answerHtml, http.StatusBadRequest, errors.New("wrong email unsubscription"), "email address in request does not match known for this user", rest.ErrInternal)
 		return
 	}
 
@@ -383,7 +405,7 @@ func (s *private) emailUnsubscribeCtrl(w http.ResponseWriter, r *http.Request) {
 
 	if err := s.dataService.DeleteUserDetail(locator, userID, engine.UserEmail); err != nil {
 		code := parseError(err, rest.ErrInternal)
-		rest.SendErrorJSON(w, r, http.StatusBadRequest, err, "can't delete email for user", code)
+		rest.SendErrorHTML(w, r, answerHtml, http.StatusBadRequest, err, "can't delete email for user", code)
 		return
 	}
 	// clean User.Email from the token, if user has the token
@@ -394,11 +416,17 @@ func (s *private) emailUnsubscribeCtrl(w http.ResponseWriter, r *http.Request) {
 	if claims.User != nil && claims.User.Email != "" {
 		claims.User.Email = ""
 		if _, err = s.authenticator.TokenService().Set(w, claims); err != nil {
-			rest.SendErrorJSON(w, r, http.StatusInternalServerError, err, "failed to set token", rest.ErrInternal)
+			rest.SendErrorHTML(w, r, answerHtml, http.StatusInternalServerError, err, "failed to set token", rest.ErrInternal)
 			return
 		}
 	}
-	render.JSON(w, r, R.JSON{"unsubscribed": true})
+
+	msg := bytes.Buffer{}
+	err = answerHtml.Execute(&msg, rest.ErrTmplData{})
+	if err != nil {
+		panic(err)
+	}
+	render.HTML(w, r, msg.String())
 }
 
 // DELETE /email?site=siteID - removes user's email

--- a/backend/app/rest/api/rest_private_test.go
+++ b/backend/app/rest/api/rest_private_test.go
@@ -492,10 +492,10 @@ func TestRest_Email(t *testing.T) {
 		{description: "delete user email", url: "/api/v1/email?site=remark42", method: http.MethodDelete, responseCode: http.StatusOK},
 		{description: "send another confirmation", url: "/api/v1/email/subscribe?site=remark42&address=good@example.com", method: http.MethodPost, responseCode: http.StatusOK},
 		{description: "set user email, token is good", url: fmt.Sprintf("/api/v1/email/confirm?site=remark42&tkn=%s", goodToken), method: http.MethodPost, responseCode: http.StatusOK, cookieEmail: "good@example.com"},
-		{description: "unsubscribe user, no token", url: "/api/v1/email/unsubscribe?site=remark42", method: http.MethodPost, responseCode: http.StatusBadRequest},
-		{description: "unsubscribe user, wrong token", url: "/api/v1/email/unsubscribe?site=remark42&tkn=jwt", method: http.MethodPost, responseCode: http.StatusForbidden},
-		{description: "unsubscribe user, good token", url: fmt.Sprintf("/api/v1/email/unsubscribe?site=remark42&tkn=%s", goodToken), method: http.MethodPost, responseCode: http.StatusOK},
-		{description: "unsubscribe user second time, good token", url: fmt.Sprintf("/api/v1/email/unsubscribe?site=remark42&tkn=%s", goodToken), method: http.MethodPost, responseCode: http.StatusConflict},
+		{description: "unsubscribe user, no token", url: "/email/unsubscribe.html?site=remark42", method: http.MethodPost, responseCode: http.StatusBadRequest},
+		{description: "unsubscribe user, wrong token", url: "/email/unsubscribe.html?site=remark42&tkn=jwt", method: http.MethodGet, responseCode: http.StatusForbidden},
+		{description: "unsubscribe user, good token", url: fmt.Sprintf("/email/unsubscribe.html?site=remark42&tkn=%s", goodToken), method: http.MethodPost, responseCode: http.StatusOK},
+		{description: "unsubscribe user second time, good token", url: fmt.Sprintf("/email/unsubscribe.html?site=remark42&tkn=%s", goodToken), method: http.MethodPost, responseCode: http.StatusConflict},
 	}
 	client := http.Client{}
 	for _, x := range testData {

--- a/backend/app/rest/httperrors.go
+++ b/backend/app/rest/httperrors.go
@@ -37,22 +37,37 @@ const (
 	ErrAssetNotFound      = 18 // requested file not found
 )
 
-// ErrTmplData store data for error message
-type ErrTmplData struct {
+const errorHtml = `<!DOCTYPE html>
+<html>
+<head>
+    <meta name="viewport" content="width=device-width"/>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+</head>
+<body>
+<div style="text-align: center; font-family: Arial, sans-serif; font-size: 18px;">
+    <h1 style="position: relative; color: #4fbbd6; margin-top: 0.2em;">Remark42</h1>
+	<p style="position: relative; max-width: 20em; margin: 0 auto 1em auto; line-height: 1.4em;">{{.Error}}: {{.Details}}.</p>
+</div>
+</body>
+</html>
+`
+
+// errTmplData store data for error message
+type errTmplData struct {
 	Error   string
 	Details string
-	Code    int
 }
 
-// SendErrorHTML makes html body with provided template and responds with error code
-func SendErrorHTML(w http.ResponseWriter, r *http.Request, tmpl *template.Template, httpStatusCode int, err error, details string, errCode int) {
+// SendErrorHTML makes html body with provided template and responds with provided http status code,
+// error code is not included in render as it is intended for UI developers and not for the users
+func SendErrorHTML(w http.ResponseWriter, r *http.Request, httpStatusCode int, err error, details string, errCode int) {
+	tmpl := template.Must(template.New("unsubscribe").Parse(errorHtml))
 	log.Printf("[WARN] %s", errDetailsMsg(r, httpStatusCode, err, details, errCode))
 	render.Status(r, httpStatusCode)
 	msg := bytes.Buffer{}
-	err = tmpl.Execute(&msg, ErrTmplData{
+	err = tmpl.Execute(&msg, errTmplData{
 		Error:   err.Error(),
 		Details: details,
-		Code:    errCode,
 	})
 	if err != nil {
 		panic(err)

--- a/backend/app/rest/httperrors.go
+++ b/backend/app/rest/httperrors.go
@@ -61,7 +61,7 @@ type errTmplData struct {
 // SendErrorHTML makes html body with provided template and responds with provided http status code,
 // error code is not included in render as it is intended for UI developers and not for the users
 func SendErrorHTML(w http.ResponseWriter, r *http.Request, httpStatusCode int, err error, details string, errCode int) {
-	tmpl := template.Must(template.New("unsubscribe").Parse(errorHtml))
+	tmpl := template.Must(template.New("error").Parse(errorHtml))
 	log.Printf("[WARN] %s", errDetailsMsg(r, httpStatusCode, err, details, errCode))
 	render.Status(r, httpStatusCode)
 	msg := bytes.Buffer{}

--- a/backend/app/rest/httperrors_test.go
+++ b/backend/app/rest/httperrors_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/umputun/remark/backend/app/store"
 )
 
@@ -34,6 +35,32 @@ func TestSendErrorJSON(t *testing.T) {
 	assert.Equal(t, 500, resp.StatusCode)
 
 	assert.Equal(t, `{"code":123,"details":"error details 123456","error":"error 500"}`+"\n", string(body))
+}
+
+func TestSendErrorHTML(t *testing.T) {
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/error" {
+			t.Log("http err request", r.URL)
+			SendErrorHTML(w, r, 500, errors.New("error 500"), "error details 123456", 123)
+			return
+		}
+		w.WriteHeader(404)
+	}))
+
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/error")
+	require.Nil(t, err)
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	require.Nil(t, err)
+	assert.Equal(t, 500, resp.StatusCode)
+
+	assert.NotContains(t, `123`, string(body))
+	assert.Contains(t, string(body), `error details 123456`)
+	assert.Contains(t, string(body), `error 500`)
 }
 
 func TestErrorDetailsMsg(t *testing.T) {

--- a/backend/app/rest/httperrors_test.go
+++ b/backend/app/rest/httperrors_test.go
@@ -42,7 +42,7 @@ func TestSendErrorHTML(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/error" {
 			t.Log("http err request", r.URL)
-			SendErrorHTML(w, r, 500, errors.New("error 500"), "error details 123456", 123)
+			SendErrorHTML(w, r, 500, errors.New("error 500"), "error details 123456", 987)
 			return
 		}
 		w.WriteHeader(404)
@@ -58,7 +58,7 @@ func TestSendErrorHTML(t *testing.T) {
 	require.Nil(t, err)
 	assert.Equal(t, 500, resp.StatusCode)
 
-	assert.NotContains(t, `123`, string(body))
+	assert.NotContains(t, string(body), `987`, "user html should not contain internal error code")
 	assert.Contains(t, string(body), `error details 123456`)
 	assert.Contains(t, string(body), `error 500`)
 }

--- a/backend/app/rest/httperrors_test.go
+++ b/backend/app/rest/httperrors_test.go
@@ -69,7 +69,9 @@ func TestErrorDetailsMsg(t *testing.T) {
 		require.Nil(t, err)
 		req.RemoteAddr = "1.2.3.4"
 		msg := errDetailsMsg(req, 500, errors.New("error 500"), "error details 123456", 123)
-		assert.Equal(t, "error details 123456 - error 500 - 500 (123) - https://example.com/test?k1=v1&k2=v2 - [app/rest/httperrors_test.go:47 rest.TestErrorDetailsMsg]", msg)
+		assert.Contains(t, msg, "error details 123456 - error 500 - 500 (123) - https://example.com/test?k1=v1&k2=v2 - [app/rest/httperrors_test.go:")
+		// error line in the middle of the message is not checked
+		assert.Contains(t, msg, " rest.TestErrorDetailsMsg]")
 	}
 	callerFn()
 }
@@ -82,8 +84,9 @@ func TestErrorDetailsMsgWithUser(t *testing.T) {
 		req = SetUserInfo(req, store.User{Name: "test", ID: "id"})
 		require.Nil(t, err)
 		msg := errDetailsMsg(req, 500, errors.New("error 500"), "error details 123456", 34567)
-		assert.Equal(t, "error details 123456 - error 500 - 500 (34567) - test/id - https://example."+
-			"com/test?k1=v1&k2=v2 - [app/rest/httperrors_test.go:61 rest.TestErrorDetailsMsgWithUser]", msg)
+		assert.Contains(t, msg, "error details 123456 - error 500 - 500 (34567) - test/id - https://example.com/test?k1=v1&k2=v2 - [app/rest/httperrors_test.go:")
+		// error line in the middle of the message is not checked
+		assert.Contains(t, msg, " rest.TestErrorDetailsMsgWithUser]")
 	}
 	callerFn()
 }


### PR DESCRIPTION
Attempt to fix #495.

I've moved unsubscribe email endpoint outside of API endpoints space because API already has `DELETE /api/v1/email` endpoint for this purpose.

Images of normal message and errors in this PR implementation:
<img width="237" alt="Screenshot 2019-12-26 at 12 41 21" src="https://user-images.githubusercontent.com/712534/71475135-44949580-27df-11ea-8a78-1a0804955819.png">
<img width="340" alt="Screenshot 2019-12-26 at 12 44 08" src="https://user-images.githubusercontent.com/712534/71475136-44949580-27df-11ea-804d-1901afa05eac.png">
<img width="378" alt="Screenshot 2019-12-26 at 12 44 30" src="https://user-images.githubusercontent.com/712534/71475137-452d2c00-27df-11ea-86e5-ca964d0bfd6d.png">
<img width="361" alt="Screenshot 2019-12-26 at 12 44 41" src="https://user-images.githubusercontent.com/712534/71475138-452d2c00-27df-11ea-9aef-0913503c8701.png">
