### PR TITLE
make TestRPC tests reliably wait for HTTP server to start

### DIFF
--- a/backend/_example/memory_store/server/rpc_test.go
+++ b/backend/_example/memory_store/server/rpc_test.go
@@ -401,7 +401,13 @@ func prepTestStore(t *testing.T) (s *RPC, port int, teardown func()) {
 		log.Printf("%v", s.Run(port))
 	}()
 
-	time.Sleep(time.Millisecond * 50) // wait for server to start
+	// wait for server to start before returning it
+	for {
+		time.Sleep(time.Millisecond * 10)
+		if _, err := http.Get(fmt.Sprintf("http://localhost:%d", port)); err == nil {
+			break
+		}
+	}
 
 	return s, port, func() {
 		require.NoError(t, s.Shutdown())

--- a/backend/_example/memory_store/server/rpc_test.go
+++ b/backend/_example/memory_store/server/rpc_test.go
@@ -401,8 +401,8 @@ func prepTestStore(t *testing.T) (s *RPC, port int, teardown func()) {
 		log.Printf("%v", s.Run(port))
 	}()
 
-	// wait for server to start before returning it
-	for {
+	// wait for up to 3 seconds for server to start before returning it
+	for i := 0; i < 300; i++ {
 		time.Sleep(time.Millisecond * 10)
 		if _, err := http.Get(fmt.Sprintf("http://localhost:%d", port)); err == nil {
 			break


### PR DESCRIPTION
Fix attached list of tests false positive failures which are caused by HTTP server which is returned to test without properly checking if it's ready or not.

| Test name | Failure date |
| --------- | ------------ |
| [TestRPC_admEnabledHndl](https://github.com/umputun/remark/blob/aafe760bafb89ed4e939ecbb091d2c71ae000b6a/backend/_example/memory_store/server/rpc_test.go#L350) | [Nov 22](https://github.com/umputun/remark/commit/aafe760bafb89ed4e939ecbb091d2c71ae000b6a/checks?check_suite_id=323640436#step:5:117) |
| [TestRPC_admEventHndl](https://github.com/umputun/remark/blob/bc1893883b6880655bae8572e753884104ebebc6/backend/_example/memory_store/server/rpc_test.go#L364) | [Dec 8](https://github.com/umputun/remark/commit/bc1893883b6880655bae8572e753884104ebebc6/checks?check_suite_id=348041164#step:5:118) |
| [TestRPC_deleteHndl](https://github.com/umputun/remark/blob/f830a8a473ecc2e2141f996a36ab6cba3bbe9999/backend/_example/memory_store/server/rpc_test.go#L279) | [Dec 29](https://github.com/umputun/remark/runs/367104452#step:5:112) |