### PR TITLE
Check if the port already in use in TestRPC_ tests server startup

### DIFF
--- a/backend/_example/memory_store/server/rpc_test.go
+++ b/backend/_example/memory_store/server/rpc_test.go
@@ -379,8 +379,6 @@ func TestRPC_admEventHndl(t *testing.T) {
 }
 
 func prepTestStore(t *testing.T) (s *RPC, port int, teardown func()) {
-	port = 40000 + int(rand.Int31n(10000))
-
 	mg := accessor.NewMemData()
 	adm := accessor.NewMemAdminStore("secret")
 	s = NewRPC(mg, adm, &jrpc.Server{API: "/test", Logger: jrpc.NoOpLogger})
@@ -397,6 +395,13 @@ func prepTestStore(t *testing.T) (s *RPC, port int, teardown func()) {
 	admRecDisabled.Enabled = false
 	adm.Set("test-site-disabled", admRecDisabled)
 
+	// check if port is in use before trying to start a new server on it
+	for i := 0; i < 10; i++ {
+		port = 40000 + int(rand.Int31n(10000))
+		if _, err := http.Get(fmt.Sprintf("http://localhost:%d", port)); err != nil {
+			break
+		}
+	}
 	go func() {
 		log.Printf("%v", s.Run(port))
 	}()

--- a/backend/_example/memory_store/server/rpc_test.go
+++ b/backend/_example/memory_store/server/rpc_test.go
@@ -9,6 +9,7 @@ package server
 import (
 	"fmt"
 	"math/rand"
+	"net"
 	"net/http"
 	"testing"
 	"time"
@@ -398,8 +399,12 @@ func prepTestStore(t *testing.T) (s *RPC, port int, teardown func()) {
 	// check if port is in use before trying to start a new server on it
 	for i := 0; i < 10; i++ {
 		port = 40000 + int(rand.Int31n(10000))
-		if _, err := http.Get(fmt.Sprintf("http://localhost:%d", port)); err != nil {
+		conn, err := net.DialTimeout("tcp", fmt.Sprintf("localhost:%d", port), time.Millisecond*10)
+		if err != nil {
 			break
+		}
+		if conn != nil {
+			conn.Close()
 		}
 	}
 	go func() {


### PR DESCRIPTION
Recently merged #505 didn't fix the attached list of tests false positive failures, which is clear from the fact that last error fired (what a luck!) on the last commit to PR branch (but in my repo, not in this one). 

The previous PR fixed the problem which is yet unseen on the SSD-disk-based setup I have locally and GitHub Actions seems to have. The real problem is within this log entry:

    INFO  listen tcp :43300: bind: address already in use

This PR tackles this problem. The solution is purely theoretical, as I can not reproduce the problem locally, unfortunately.

| Test name | Failure date |
| --------- | ------------ |
| [TestRPC_admEnabledHndl](https://github.com/umputun/remark/blob/aafe760bafb89ed4e939ecbb091d2c71ae000b6a/backend/_example/memory_store/server/rpc_test.go#L350) | [Nov 22](https://github.com/umputun/remark/commit/aafe760bafb89ed4e939ecbb091d2c71ae000b6a/checks?check_suite_id=323640436#step:5:117) |
| [TestRPC_admEventHndl](https://github.com/umputun/remark/blob/bc1893883b6880655bae8572e753884104ebebc6/backend/_example/memory_store/server/rpc_test.go#L364) | [Dec 8](https://github.com/umputun/remark/commit/bc1893883b6880655bae8572e753884104ebebc6/checks?check_suite_id=348041164#step:5:118) |
| [TestRPC_deleteHndl](https://github.com/umputun/remark/blob/f830a8a473ecc2e2141f996a36ab6cba3bbe9999/backend/_example/memory_store/server/rpc_test.go#L279) | [Dec 29](https://github.com/umputun/remark/runs/367104452#step:5:112)
| [TestRPC_listFlagsHndl](https://github.com/umputun/remark/blob/ee63763120b5daf05e52402d720ceeb808c5fee7/backend/_example/memory_store/server/rpc_test.go#L192) | [Dec 29](https://github.com/paskal/remark/runs/367129050#step:5:110) |