### PR TITLE
Improve TestServer* tests reliability

### DIFF
--- a/backend/_example/memory_store/server/rpc_test.go
+++ b/backend/_example/memory_store/server/rpc_test.go
@@ -404,7 +404,7 @@ func prepTestStore(t *testing.T) (s *RPC, port int, teardown func()) {
 			break
 		}
 		if conn != nil {
-			conn.Close()
+			_ = conn.Close()
 		}
 	}
 	go func() {

--- a/backend/_example/memory_store/server/rpc_test.go
+++ b/backend/_example/memory_store/server/rpc_test.go
@@ -379,15 +379,12 @@ func TestRPC_admEventHndl(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func chooseOpenRandomPort(start, random int) (port int) {
+func chooseRandomUnusedPort() (port int) {
 	for i := 0; i < 10; i++ {
-		port = start + int(rand.Int31n(int32(random)))
-		conn, err := net.DialTimeout("tcp", fmt.Sprintf("localhost:%d", port), time.Millisecond*10)
-		if err != nil {
+		port = 40000 + int(rand.Int31n(10000))
+		if ln, err := net.Listen("tcp", fmt.Sprintf(":%d", port)); err == nil {
+			_ = ln.Close()
 			break
-		}
-		if conn != nil {
-			_ = conn.Close()
 		}
 	}
 	return port
@@ -422,7 +419,7 @@ func prepTestStore(t *testing.T) (s *RPC, port int, teardown func()) {
 	admRecDisabled.Enabled = false
 	adm.Set("test-site-disabled", admRecDisabled)
 
-	port = chooseOpenRandomPort(40000, 10000)
+	port = chooseRandomUnusedPort()
 	go func() {
 		log.Printf("%v", s.Run(port))
 	}()

--- a/backend/_example/memory_store/server/rpc_test.go
+++ b/backend/_example/memory_store/server/rpc_test.go
@@ -412,9 +412,11 @@ func prepTestStore(t *testing.T) (s *RPC, port int, teardown func()) {
 	}()
 
 	// wait for up to 3 seconds for server to start before returning it
+	client := http.Client{Timeout: time.Second}
 	for i := 0; i < 300; i++ {
 		time.Sleep(time.Millisecond * 10)
-		if _, err := http.Get(fmt.Sprintf("http://localhost:%d", port)); err == nil {
+		if resp, err := client.Get(fmt.Sprintf("http://localhost:%d", port)); err == nil {
+			_ = resp.Body.Close()
 			break
 		}
 	}

--- a/backend/app/cmd/cleanup.go
+++ b/backend/app/cmd/cleanup.go
@@ -131,7 +131,8 @@ func (cc *CleanupCommand) postsInRange(fromS, toS string) ([]store.PostInfo, err
 // get all posts via GET /list?site=siteID&limit=50&skip=10
 func (cc *CleanupCommand) listPosts() ([]store.PostInfo, error) {
 	listURL := fmt.Sprintf("%s/api/v1/list?site=%s&limit=10000", cc.RemarkURL, cc.Site)
-	r, err := http.Get(listURL) // nolint
+	client := http.Client{Timeout: 30 * time.Second}
+	r, err := client.Get(listURL)
 	if err != nil {
 		return nil, errors.Wrapf(err, "get request failed for list of posts, site %s", cc.Site)
 	}
@@ -158,7 +159,8 @@ func (cc *CleanupCommand) listComments(postURL string) ([]store.Comment, error) 
 
 	// handle 429 error from limiter
 	for {
-		r, err = http.Get(commentsURL) // nolint
+		client := http.Client{Timeout: 30 * time.Second}
+		r, err = client.Get(commentsURL)
 		if err != nil {
 			return nil, errors.Wrapf(err, "get request failed for comments, %s", postURL)
 		}

--- a/backend/app/cmd/server_test.go
+++ b/backend/app/cmd/server_test.go
@@ -158,15 +158,7 @@ func TestServerApp_WithSSL(t *testing.T) {
 		cancel()
 	}()
 	go func() { _ = app.run(ctx) }()
-	// wait for up to 1 seconds for HTTPS server to start
-	for i := 0; i < 100; i++ {
-		time.Sleep(time.Millisecond * 10)
-		conn, _ := net.DialTimeout("tcp", fmt.Sprintf("localhost:%d", sslPort), time.Millisecond*10)
-		if conn != nil {
-			_ = conn.Close()
-			break
-		}
-	}
+	waitForHTTPSServerStart(sslPort)
 
 	client := http.Client{
 		// prevent http redirect
@@ -487,6 +479,18 @@ func waitForHTTPServerStart(port int) {
 		if resp, err := client.Get(fmt.Sprintf("http://localhost:%d", port)); err == nil {
 			_ = resp.Body.Close()
 			return
+		}
+	}
+}
+
+func waitForHTTPSServerStart(port int) {
+	// wait for up to 3 seconds for HTTPS server to start
+	for i := 0; i < 300; i++ {
+		time.Sleep(time.Millisecond * 10)
+		conn, _ := net.DialTimeout("tcp", fmt.Sprintf("localhost:%d", sslPort), time.Millisecond*10)
+		if conn != nil {
+			_ = conn.Close()
+			break
 		}
 	}
 }

--- a/backend/app/cmd/server_test.go
+++ b/backend/app/cmd/server_test.go
@@ -484,7 +484,7 @@ func waitForHTTPSServerStart(port int) {
 	// wait for up to 3 seconds for HTTPS server to start
 	for i := 0; i < 300; i++ {
 		time.Sleep(time.Millisecond * 10)
-		conn, _ := net.DialTimeout("tcp", fmt.Sprintf("localhost:%d", sslPort), time.Millisecond*10)
+		conn, _ := net.DialTimeout("tcp", fmt.Sprintf("localhost:%d", port), time.Millisecond*10)
 		if conn != nil {
 			_ = conn.Close()
 			break

--- a/backend/app/rest/api/rest_test.go
+++ b/backend/app/rest/api/rest_test.go
@@ -134,7 +134,7 @@ func TestRest_RunStaticSSLMode(t *testing.T) {
 			break
 		}
 		if conn != nil {
-			conn.Close()
+			_ = conn.Close()
 		}
 	}
 	go func() {
@@ -146,7 +146,7 @@ func TestRest_RunStaticSSLMode(t *testing.T) {
 		time.Sleep(time.Millisecond * 10)
 		conn, _ := net.DialTimeout("tcp", fmt.Sprintf("localhost:%d", port), time.Millisecond*10)
 		if conn != nil {
-			conn.Close()
+			_ = conn.Close()
 			break
 		}
 	}
@@ -200,7 +200,7 @@ func TestRest_RunAutocertModeHTTPOnly(t *testing.T) {
 			break
 		}
 		if conn != nil {
-			conn.Close()
+			_ = conn.Close()
 		}
 	}
 	go func() {
@@ -213,7 +213,7 @@ func TestRest_RunAutocertModeHTTPOnly(t *testing.T) {
 		time.Sleep(time.Millisecond * 10)
 		conn, _ := net.DialTimeout("tcp", fmt.Sprintf("localhost:%d", port), time.Millisecond*10)
 		if conn != nil {
-			conn.Close()
+			_ = conn.Close()
 			break
 		}
 	}

--- a/backend/app/rest/api/rest_test.go
+++ b/backend/app/rest/api/rest_test.go
@@ -125,7 +125,7 @@ func TestRest_RunStaticSSLMode(t *testing.T) {
 		RemarkURL: "https://localhost:8443",
 	}
 
-	port := chooseOpenRandomPort(40000, 10000)
+	port := chooseRandomUnusedPort()
 	go func() {
 		srv.Run(port)
 	}()
@@ -172,7 +172,7 @@ func TestRest_RunAutocertModeHTTPOnly(t *testing.T) {
 		RemarkURL: "https://localhost:8443",
 	}
 
-	port := chooseOpenRandomPort(40000, 10000)
+	port := chooseRandomUnusedPort()
 	go func() {
 		// can't check https server locally, just only http server
 		srv.Run(port)
@@ -469,15 +469,12 @@ func requireAdminOnly(t *testing.T, req *http.Request) {
 	assert.Equal(t, 403, resp.StatusCode)
 }
 
-func chooseOpenRandomPort(start, random int) (port int) {
+func chooseRandomUnusedPort() (port int) {
 	for i := 0; i < 10; i++ {
-		port = start + int(rand.Int31n(int32(random)))
-		conn, err := net.DialTimeout("tcp", fmt.Sprintf("localhost:%d", port), time.Millisecond*10)
-		if err != nil {
+		port = 40000 + int(rand.Int31n(10000))
+		if ln, err := net.Listen("tcp", fmt.Sprintf(":%d", port)); err == nil {
+			_ = ln.Close()
 			break
-		}
-		if conn != nil {
-			_ = conn.Close()
 		}
 	}
 	return port

--- a/backend/app/rest/api/rest_test.go
+++ b/backend/app/rest/api/rest_test.go
@@ -125,31 +125,12 @@ func TestRest_RunStaticSSLMode(t *testing.T) {
 		RemarkURL: "https://localhost:8443",
 	}
 
-	// check if port is in use before trying to start a new server on it
-	var port int
-	for i := 0; i < 10; i++ {
-		port = 40000 + int(rand.Int31n(10000))
-		conn, err := net.DialTimeout("tcp", fmt.Sprintf("localhost:%d", port), time.Millisecond*10)
-		if err != nil {
-			break
-		}
-		if conn != nil {
-			_ = conn.Close()
-		}
-	}
+	port := chooseOpenRandomPort(40000, 10000)
 	go func() {
 		srv.Run(port)
 	}()
 
-	// wait for up to 3 seconds for server to start
-	for i := 0; i < 300; i++ {
-		time.Sleep(time.Millisecond * 10)
-		conn, _ := net.DialTimeout("tcp", fmt.Sprintf("localhost:%d", port), time.Millisecond*10)
-		if conn != nil {
-			_ = conn.Close()
-			break
-		}
-	}
+	waitForHTTPServerStart(port)
 
 	client := http.Client{
 		// prevent http redirect
@@ -191,32 +172,13 @@ func TestRest_RunAutocertModeHTTPOnly(t *testing.T) {
 		RemarkURL: "https://localhost:8443",
 	}
 
-	// check if port is in use before trying to start a new server on it
-	var port int
-	for i := 0; i < 10; i++ {
-		port = 40000 + int(rand.Int31n(10000))
-		conn, err := net.DialTimeout("tcp", fmt.Sprintf("localhost:%d", port), time.Millisecond*10)
-		if err != nil {
-			break
-		}
-		if conn != nil {
-			_ = conn.Close()
-		}
-	}
+	port := chooseOpenRandomPort(40000, 10000)
 	go func() {
 		// can't check https server locally, just only http server
 		srv.Run(port)
 	}()
 
-	// wait for up to 3 seconds for server to start
-	for i := 0; i < 300; i++ {
-		time.Sleep(time.Millisecond * 10)
-		conn, _ := net.DialTimeout("tcp", fmt.Sprintf("localhost:%d", port), time.Millisecond*10)
-		if conn != nil {
-			_ = conn.Close()
-			break
-		}
-	}
+	waitForHTTPServerStart(port)
 
 	client := http.Client{
 		// prevent http redirect
@@ -505,4 +467,30 @@ func requireAdminOnly(t *testing.T, req *http.Request) {
 	resp, err = sendReq(t, req, devToken) // non-admin user
 	require.NoError(t, err)
 	assert.Equal(t, 403, resp.StatusCode)
+}
+
+func chooseOpenRandomPort(start, random int) (port int) {
+	for i := 0; i < 10; i++ {
+		port = start + int(rand.Int31n(int32(random)))
+		conn, err := net.DialTimeout("tcp", fmt.Sprintf("localhost:%d", port), time.Millisecond*10)
+		if err != nil {
+			break
+		}
+		if conn != nil {
+			_ = conn.Close()
+		}
+	}
+	return port
+}
+
+func waitForHTTPServerStart(port int) {
+	// wait for up to 3 seconds for server to start before returning it
+	client := http.Client{Timeout: time.Second}
+	for i := 0; i < 300; i++ {
+		time.Sleep(time.Millisecond * 10)
+		if resp, err := client.Get(fmt.Sprintf("http://localhost:%d", port)); err == nil {
+			_ = resp.Body.Close()
+			return
+		}
+	}
 }


### PR DESCRIPTION
This PR might prevent failures like following (first 4 failures root cause is not clear):

| Test name | Failure date |
| --------- | ------------ |
| [TestServerApp](https://github.com/umputun/remark/blob/cdc1ae1e85d6efe5f0bbf341df71a77bfe09cd2e/backend/app/cmd/server_test.go#L25) | [Oct 14](https://github.com/umputun/remark/commit/8315299676961cf00de10d45923d5e318d12e484/checks?check_suite_id=264658757#step:5:244) |
| [TestServerApp](https://github.com/umputun/remark/blob/cdc1ae1e85d6efe5f0bbf341df71a77bfe09cd2e/backend/app/cmd/server_test.go#L25) | [Oct 16](https://github.com/umputun/remark/commit/3e4f9d6f02a6c8b204354f781c8b7d2c1a7d3941/checks?check_suite_id=266861491#step:5:244) |
| [TestServerApp](https://github.com/umputun/remark/blob/ee63763120b5daf05e52402d720ceeb808c5fee7/backend/app/cmd/server_test.go#L25) | [Dec 29](https://github.com/umputun/remark/runs/367129051#step:5:75) |
| [TestServerApp_AnonMode](https://github.com/umputun/remark/blob/7bab10ab5741e6dc905a977ee3f18024a99d3327/backend/app/cmd/server_test.go#L90) | [Dec 11](https://github.com/paskal/remark/commit/36629cc57fb3a80a55de29e3a059d0ad6d8939af/checks?check_suite_id=354021014#step:5:132) |
| [TestRPC_closeHndl](https://github.com/umputun/remark/blob/b82be0cc2dfa4cc74995cad8df43c3c6bf7f497c/backend/_example/memory_store/server/rpc_test.go#L303) | [Dec 30](https://github.com/paskal/remark/runs/367256059#step:5:113)|

Also:
- start using `chooseRandomUnusedPort`, `waitForHTTPServerStart`, and `waitForHTTPSServerStart` functions in test code in a same manner
- refactor `chooseRandomUnusedPort` into actually trying to listen for the port it will return, as previous version [did not work](https://github.com/paskal/remark/runs/367256059#step:5:113) and same error `listen tcp :40694: bind: address already in use` happened
- close the response body in `waitForHTTPServerStart`, which was leaking open file descriptors previously (discovered on `go test -count=30 ./...`)
- in two places in production code replace `http.Get` with default HTTP client with `http.Client{Timeout: 30 * time.Second}; r, err := client.Get(listURL)` to prevent using client without timeout.