### PR TITLE
Improve Test_Main reliability

### DIFF
--- a/backend/app/cmd/server_test.go
+++ b/backend/app/cmd/server_test.go
@@ -135,12 +135,12 @@ func TestServerApp_AnonMode(t *testing.T) {
 
 func TestServerApp_WithSSL(t *testing.T) {
 	opts := ServerCommand{}
-	opts.SetCommon(CommonOpts{RemarkURL: "https://localhost:18443", SharedSecret: "123456"})
+	sslPort := chooseRandomUnusedPort()
+	opts.SetCommon(CommonOpts{RemarkURL: fmt.Sprintf("https://localhost:%d", sslPort), SharedSecret: "123456"})
 
 	// prepare options
 	p := flags.NewParser(&opts, flags.Default)
 	port := chooseRandomUnusedPort()
-	sslPort := chooseRandomUnusedPort()
 	_, err := p.ParseArgs([]string{"--admin-passwd=password", "--port=" + strconv.Itoa(port), "--store.bolt.path=/tmp/xyz", "--backup=/tmp",
 		"--avatar.type=bolt", "--avatar.bolt.file=/tmp/ava-test.db", "--notify.type=none",
 		"--ssl.type=static", "--ssl.cert=testdata/cert.pem", "--ssl.key=testdata/key.pem",
@@ -177,7 +177,7 @@ func TestServerApp_WithSSL(t *testing.T) {
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	assert.Equal(t, 307, resp.StatusCode)
-	assert.Equal(t, "https://localhost:18443/blah?param=1", resp.Header.Get("Location"))
+	assert.Equal(t, fmt.Sprintf("https://localhost:%d/blah?param=1", sslPort), resp.Header.Get("Location"))
 
 	// check https server
 	resp, err = client.Get(fmt.Sprintf("https://localhost:%d/ping", sslPort))

--- a/backend/app/cmd/server_test.go
+++ b/backend/app/cmd/server_test.go
@@ -152,8 +152,9 @@ func TestServerApp_WithSSL(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
 	go func() {
-		time.Sleep(1 * time.Second)
+		<-done
 		log.Print("[TEST] terminate app")
 		cancel()
 	}()
@@ -188,6 +189,7 @@ func TestServerApp_WithSSL(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "pong", string(body))
 
+	close(done)
 	app.Wait()
 }
 
@@ -211,8 +213,9 @@ func TestServerApp_WithRemote(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
 	go func() {
-		time.Sleep(5 * time.Second)
+		<-done
 		log.Print("[TEST] terminate app")
 		cancel()
 	}()
@@ -228,6 +231,7 @@ func TestServerApp_WithRemote(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "pong", string(body))
 
+	close(done)
 	app.Wait()
 }
 


### PR DESCRIPTION
Fix following failures potentially:

| Test name | Failure date |
| --------- | ------------ |
| [Test_Main](https://github.com/umputun/remark/blob/cb60261124a7648fe2ae735e78833ff0dff54d4c/backend/app/main_test.go#L21) | [Oct 18](https://github.com/umputun/remark/commit/cb60261124a7648fe2ae735e78833ff0dff54d4c/checks?check_suite_id=271350649#step:5:210) |
| [Test_Main](https://github.com/umputun/remark/blob/f859239bdf9ac8d72b6a6bb2368764e720c822d8/backend/app/main_test.go#L21) | [Oct 29](https://github.com/umputun/remark/commit/f859239bdf9ac8d72b6a6bb2368764e720c822d8/checks?check_suite_id=285601644#step:5:214) |
| [Test_Main](https://github.com/umputun/remark/blob/c273828647e32aea21622eb0c4b7be02c3d6de19/backend/app/main_test.go#L21) | [Oct 31](https://github.com/umputun/remark/commit/c273828647e32aea21622eb0c4b7be02c3d6de19/checks?check_suite_id=290398749#step:5:214) |
| [Test_Main](https://github.com/umputun/remark/blob/c273828647e32aea21622eb0c4b7be02c3d6de19/backend/app/main_test.go#L21) | [Dec 30](https://github.com/paskal/remark/runs/367524352#step:5:41) |

Previously TestMain used repeater, now instead of trying it reliably chooses random open port for test and reliably waits up to 5 seconds (same limit as before) before making test request. Previously test took 5 seconds every time, now single run takes 20ms on my machine.

Also, I've made `TestServerApp*` more reliable by removing `time.Sleep` from them and using channel for proper canceling syncronisation as well.