### PR TITLE
Fix flapping TestRest_ tests

### DIFF
--- a/backend/app/cmd/server_test.go
+++ b/backend/app/cmd/server_test.go
@@ -43,7 +43,7 @@ func TestServerApp(t *testing.T) {
 	assert.Equal(t, "pong", string(body))
 
 	// add comment
-	client := http.Client{Timeout: 5 * time.Second}
+	client := http.Client{Timeout: 10 * time.Second}
 	req, err := http.NewRequest("POST", fmt.Sprintf("http://localhost:%d/api/v1/comment", port),
 		strings.NewReader(`{"text": "test 123", "locator":{"url": "https://radio-t.com/blah1", "site": "remark"}}`))
 	require.NoError(t, err)

--- a/backend/app/main_test.go
+++ b/backend/app/main_test.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -36,11 +35,10 @@ func Test_Main(t *testing.T) {
 		require.NoError(t, err)
 	}()
 
-	wg := sync.WaitGroup{}
-	wg.Add(1)
+	finished := make(chan struct{})
 	go func() {
 		main()
-		wg.Done()
+		close(finished)
 	}()
 
 	waitForHTTPServerStart(port)
@@ -53,7 +51,7 @@ func Test_Main(t *testing.T) {
 	assert.Equal(t, "pong", string(body))
 
 	close(done)
-	wg.Wait()
+	<-finished
 }
 
 func TestGetDump(t *testing.T) {

--- a/backend/app/rest/api/rest_public_test.go
+++ b/backend/app/rest/api/rest_public_test.go
@@ -650,11 +650,10 @@ func TestRest_InfoStreamCancel(t *testing.T) {
 	require.NoError(t, err)
 	defer r.Body.Close()
 	<-ctx.Done()
+	<-done
 	body, err := ioutil.ReadAll(r.Body)
 	require.EqualError(t, err, "context deadline exceeded")
 	assert.Equal(t, 200, r.StatusCode)
-
-	<-done
 
 	recs := strings.Count(string(body), "data:")
 	require.Equal(t, 1, recs, "should have 1 event:\n", string(body))
@@ -723,11 +722,11 @@ func TestRest_LastCommentsStream(t *testing.T) {
 	r, err := client.Do(req)
 	require.NoError(t, err)
 	defer r.Body.Close()
+	<-done
 	body, err := ioutil.ReadAll(r.Body)
 	require.NoError(t, err)
 	assert.Equal(t, 200, r.StatusCode)
 
-	<-done
 	assert.Equal(t, "text/event-stream", r.Header.Get("content-type"))
 	assert.Equal(t, "keep-alive", r.Header.Get("connection"))
 
@@ -779,12 +778,11 @@ func TestRest_LastCommentsStreamCancel(t *testing.T) {
 	req = req.WithContext(ctx)
 	r, err := client.Do(req)
 	require.NoError(t, err)
+	<-done
 	defer r.Body.Close()
 	body, err := ioutil.ReadAll(r.Body)
 	require.EqualError(t, err, "context deadline exceeded")
 	assert.Equal(t, 200, r.StatusCode)
-
-	<-done
 
 	recs := strings.Split(strings.TrimSuffix(string(body), "\n"), "\n")
 	assert.True(t, len(recs) < 30, "less 10 events")

--- a/backend/app/rest/api/rest_public_test.go
+++ b/backend/app/rest/api/rest_public_test.go
@@ -833,7 +833,7 @@ func TestRest_LastCommentsStreamSince(t *testing.T) {
 	go func() {
 		defer close(done)
 		for i := 1; i < 10; i++ {
-			time.Sleep(300 * time.Millisecond)
+			time.Sleep(50 * time.Millisecond)
 			postComment(t, ts.URL)
 		}
 	}()
@@ -843,12 +843,12 @@ func TestRest_LastCommentsStreamSince(t *testing.T) {
 	require.NoError(t, err)
 	r, err := client.Do(req)
 	require.NoError(t, err)
+	<-done
 	defer r.Body.Close()
 	body, err := ioutil.ReadAll(r.Body)
 	require.NoError(t, err)
 	assert.Equal(t, 200, r.StatusCode)
 
-	<-done
 	assert.Equal(t, "text/event-stream", r.Header.Get("content-type"))
 
 	recs := strings.Split(strings.TrimSuffix(string(body), "\n"), "\n")

--- a/backend/app/rest/api/rest_public_test.go
+++ b/backend/app/rest/api/rest_public_test.go
@@ -625,7 +625,7 @@ func TestRest_InfoStreamCancel(t *testing.T) {
 	ts, srv, teardown := startupT(t)
 	defer teardown()
 	srv.pubRest.readOnlyAge = 10000000 // make sure we don't hit read-only
-	srv.pubRest.streamer.Refresh = 5 * time.Millisecond
+	srv.pubRest.streamer.Refresh = 10 * time.Millisecond
 	srv.pubRest.streamer.TimeOut = 1500 * time.Millisecond
 	srv.pubRest.streamer.MaxActive = 100
 
@@ -643,7 +643,7 @@ func TestRest_InfoStreamCancel(t *testing.T) {
 	client := http.Client{}
 	req, err := http.NewRequest("GET", ts.URL+"/api/v1/stream/info?site=remark42&url=https://radio-t.com/blah1", nil)
 	require.NoError(t, err)
-	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 1000*time.Millisecond)
 	defer cancel()
 	req = req.WithContext(ctx)
 	r, err := client.Do(req)

--- a/backend/app/rest/api/rest_public_test.go
+++ b/backend/app/rest/api/rest_public_test.go
@@ -833,7 +833,7 @@ func TestRest_LastCommentsStreamSince(t *testing.T) {
 	go func() {
 		defer close(done)
 		for i := 1; i < 10; i++ {
-			time.Sleep(100 * time.Millisecond)
+			time.Sleep(300 * time.Millisecond)
 			postComment(t, ts.URL)
 		}
 	}()
@@ -852,7 +852,7 @@ func TestRest_LastCommentsStreamSince(t *testing.T) {
 	assert.Equal(t, "text/event-stream", r.Header.Get("content-type"))
 
 	recs := strings.Split(strings.TrimSuffix(string(body), "\n"), "\n")
-	require.Equal(t, 10*3, len(recs), "10 events, includes first record")
+	require.Equal(t, 10*3, len(recs), "should be 10 events, including first record:\n", recs)
 }
 
 func postComment(t *testing.T, url string) {


### PR DESCRIPTION
$subj, `<-done` position was wrong in multiple locations in `rest_public_test.go`. 6 test runs of GitHub Actions I've conducted haven't shown any problems after this PR.