### PR TITLE
Fix typescript error that might be caused under windows

### DIFF
--- a/frontend/app/components/dropdown/dropdown.tsx
+++ b/frontend/app/components/dropdown/dropdown.tsx
@@ -106,7 +106,7 @@ export default class Dropdown extends Component<Props, State> {
   __onClose() {
     window.clearInterval(this.checkInterval);
     if (this.storedDocumentHeightSet) {
-      document.body.style.minHeight = this.storedDocumentHeight;
+      document.body.style.minHeight = typeof this.storedDocumentHeight === 'string' ? this.storedDocumentHeight : '';
     }
   }
 


### PR DESCRIPTION
I fixed this error which was mentioned in this #490 
```
/remark/frontend/app/components/dropdown/dropdown.tsx(109,7)
      TS2322: Type 'string | null' is not assignable to type 'string'.
  Type 'null' is not assignable to type 'string'.
```