### PR TITLE
Fix TestServerApp_MainSignal

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -63,6 +63,6 @@ jobs:
       env:
         COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: build docker image
+    - name: build docker image with frontend tests
       run: docker build --build-arg SKIP_BACKEND_TEST=true --build-arg CI=github .
 

--- a/backend/app/cmd/server_test.go
+++ b/backend/app/cmd/server_test.go
@@ -287,12 +287,13 @@ func TestServerApp_Shutdown(t *testing.T) {
 
 func TestServerApp_MainSignal(t *testing.T) {
 
+	done := make(chan struct{})
 	go func() {
+		<-done
 		time.Sleep(250 * time.Millisecond)
 		err := syscall.Kill(syscall.Getpid(), syscall.SIGTERM)
 		require.NoError(t, err)
 	}()
-	st := time.Now()
 
 	s := ServerCommand{}
 	s.SetCommon(CommonOpts{RemarkURL: "https://demo.remark42.com", SharedSecret: "123456"})
@@ -304,9 +305,11 @@ func TestServerApp_MainSignal(t *testing.T) {
 	defer os.Remove("/tmp/ava-test.db")
 	_, err := p.ParseArgs(args)
 	require.NoError(t, err)
+	st := time.Now()
+	close(done)
 	err = s.Execute(args)
-	assert.NoError(t, err, "execute failed")
-	assert.True(t, time.Since(st).Seconds() < 1, "should take under sec", time.Since(st).Seconds())
+	assert.NoError(t, err, "execute should be without errors")
+	assert.True(t, time.Since(st).Seconds() < 5, "should take under five sec", time.Since(st).Seconds())
 }
 
 func Test_ACMEEmail(t *testing.T) {


### PR DESCRIPTION
- potentially make TestServerApp_MainSignal more robust (next time I'll tear all "should be finished within X seconds" away from test code);
- rename last build step to `build docker image with frontend tests` because that's what it is.