### PR TITLE
Fix right-to-left typing in IE11/Edge

### DIFF
--- a/frontend/app/components/input/textarea-autosize.tsx
+++ b/frontend/app/components/input/textarea-autosize.tsx
@@ -66,12 +66,6 @@ export default class TextareaAutosize extends Component<Props> {
     }
   }
   render(props: Props) {
-    return (
-      // We set text as a child of textarea and not in value property for a reason.
-      // It's a workaround for the bug described here https://github.com/developit/preact/issues/326
-      <textarea {...props} ref={this.onRef}>
-        {props.value}
-      </textarea>
-    );
+    return <textarea {...props} ref={this.onRef} />;
   }
 }


### PR DESCRIPTION
This issue was closed https://github.com/developit/preact/issues/326 and now we can pass value right to textarea `value` attribute.

It should fix #484 issue.