### PR TITLE
[CI] Separate tests and build, frontend and backend tests

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -4,8 +4,21 @@ on:
   push:
     branches:
     tags:
+    paths:
+    - '.github/workflows/ci-build.yml'
+    - 'backend/**'
+    - 'frontend/**'
+    - '.dockerignore'
+    - 'docker-init.sh'
+    - 'Dockerfile'
   pull_request:
-
+    paths:
+    - '.github/workflows/ci-build.yml'
+    - 'backend/**'
+    - 'frontend/**'
+    - '.dockerignore'
+    - 'docker-init.sh'
+    - 'Dockerfile'
 
 jobs:
   build:
@@ -14,55 +27,5 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
-    - name: debug if needed
-      run: |
-        export DEBUG=${DEBUG:-false}
-        if [[ "$DEBUG" == "true" ]]; then
-          env
-        fi
-      env:
-        DEBUG: ${{secrets.DEBUG}}
-
-    - name: install go
-      uses: actions/setup-go@v1
-      with:
-        go-version: 1.13
-
-    - name: build and test backend
-      run: |
-        export TZ="America/Chicago"
-        date
-        cd backend/app
-        go test -mod=vendor -timeout=60s -covermode=count -coverprofile=$GITHUB_WORKSPACE/profile.cov_tmp ./...
-        cat $GITHUB_WORKSPACE/profile.cov_tmp | grep -v "_mock.go" > $GITHUB_WORKSPACE/profile.cov
-        cd ../_example/memory_store
-        go test -race ./...
-
-    - name: install golangci-lint and goveralls
-      run: |
-        curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $GITHUB_WORKSPACE v1.20.0
-        go get -u github.com/mattn/goveralls
-
-    - name: run backend linters
-      run: |
-        cd backend
-        $GITHUB_WORKSPACE/golangci-lint run --out-format=tab --disable-all --tests=false --enable=unconvert \
-          --enable=megacheck --enable=structcheck --enable=gas --enable=gocyclo --enable=dupl --enable=misspell \
-          --enable=unparam --enable=varcheck --enable=deadcode --enable=typecheck \
-          --enable=ineffassign --enable=varcheck ./... ;
-        cd _example/memory_store
-        $GITHUB_WORKSPACE/golangci-lint run --out-format=tab --disable-all --tests=false --enable=unconvert \
-          --enable=megacheck --enable=structcheck --enable=gas --enable=gocyclo --enable=dupl --enable=misspell \
-          --enable=unparam --enable=varcheck --enable=deadcode --enable=typecheck \
-          --enable=ineffassign --enable=varcheck ./... ;
-
-    - name: submit coverage
-      run: |
-        cd backend
-        $(go env GOPATH)/bin/goveralls -service="github" -coverprofile=$GITHUB_WORKSPACE/profile.cov
-      env:
-        COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: build docker image with frontend tests
-      run: docker build --build-arg SKIP_BACKEND_TEST=true --build-arg CI=github .
-
+    - name: build docker image
+      run: docker build --build-arg SKIP_BACKEND_TEST=true --build-arg SKIP_FRONTEND_TEST=true --build-arg CI=github .

--- a/.github/workflows/ci-test-backend.yml
+++ b/.github/workflows/ci-test-backend.yml
@@ -1,0 +1,71 @@
+name: test_backend
+
+on:
+  push:
+    branches:
+    tags:
+    paths:
+    - '.github/workflows/ci-test-backend.yml'
+    - 'backend/**'
+    - '!backend/scripts/**'
+  pull_request:
+    paths:
+    - '.github/workflows/ci-test-backend.yml'
+    - 'backend/**'
+    - '!backend/scripts/**'
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: debug if needed
+      run: |
+        export DEBUG=${DEBUG:-false}
+        if [[ "$DEBUG" == "true" ]]; then
+          env
+        fi
+      env:
+        DEBUG: ${{secrets.DEBUG}}
+
+    - name: install go
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.13
+
+    - name: test backend
+      run: |
+        export TZ="America/Chicago"
+        date
+        cd backend/app
+        go test -mod=vendor -timeout=60s -covermode=count -coverprofile=$GITHUB_WORKSPACE/profile.cov_tmp ./...
+        cat $GITHUB_WORKSPACE/profile.cov_tmp | grep -v "_mock.go" > $GITHUB_WORKSPACE/profile.cov
+        cd ../_example/memory_store
+        go test -race ./...
+
+    - name: install golangci-lint and goveralls
+      run: |
+        curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $GITHUB_WORKSPACE v1.20.0
+        go get -u github.com/mattn/goveralls
+
+    - name: run backend linters
+      run: |
+        cd backend
+        $GITHUB_WORKSPACE/golangci-lint run --out-format=tab --disable-all --tests=false --enable=unconvert \
+          --enable=megacheck --enable=structcheck --enable=gas --enable=gocyclo --enable=dupl --enable=misspell \
+          --enable=unparam --enable=varcheck --enable=deadcode --enable=typecheck \
+          --enable=ineffassign --enable=varcheck ./... ;
+        cd _example/memory_store
+        $GITHUB_WORKSPACE/golangci-lint run --out-format=tab --disable-all --tests=false --enable=unconvert \
+          --enable=megacheck --enable=structcheck --enable=gas --enable=gocyclo --enable=dupl --enable=misspell \
+          --enable=unparam --enable=varcheck --enable=deadcode --enable=typecheck \
+          --enable=ineffassign --enable=varcheck ./... ;
+
+    - name: submit coverage
+      run: |
+        cd backend
+        $(go env GOPATH)/bin/goveralls -service="github" -coverprofile=$GITHUB_WORKSPACE/profile.cov
+      env:
+        COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-test-frontend.yml
+++ b/.github/workflows/ci-test-frontend.yml
@@ -1,0 +1,27 @@
+name: test_frontend
+
+on:
+  push:
+    branches:
+    tags:
+    paths:
+    - '.github/workflows/ci-test-frontend.yml'
+    - 'frontend/**'
+  pull_request:
+    paths:
+    - '.github/workflows/ci-test-frontend.yml'
+    - 'frontend/**'
+
+jobs:
+  frontend:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-node@v1
+    - run: npm ci
+      working-directory: ./frontend
+    - run: npx run-p check lint test build
+      working-directory: ./frontend
+    - run: npm run build
+      working-directory: ./frontend

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ ARG NODE_ENV=production
 COPY --from=build-frontend-deps /srv/frontend/node_modules /srv/frontend/node_modules
 ADD frontend /srv/frontend
 RUN cd /srv/frontend && \
-    if [ -z "$SKIP_FRONTEND_TEST" ] ; then npx run-p lint test build ; \
+    if [ -z "$SKIP_FRONTEND_TEST" ] ; then npx run-p check lint test build ; \
     else echo "skip frontend tests and lint" ; npm run build ; fi && \
     rm -rf ./node_modules
 


### PR DESCRIPTION
Fix #521.
Separates the CI pipeline into the build, test for backend, and test for frontend. Also, introduce conditional build, so backend won't be tested on frontend changes.

Results of the change can be observed [here](https://github.com/paskal/remark/commits/ci_test_branch) after `separate build and test CI workflow, separate frontend and backend tests` commit.