### PR TITLE
Fixed "Improve quality of images #488" (sharp vibrant awesome images)

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,8 @@ _this is the recommended way to run remark42_
 | image.fs.staging        | IMAGE_FS_STAGING        | `./var/pictures.staging` | staging location of images                      |
 | image.fs.partitions     | IMAGE_FS_PARTITIONS     | `100`                    | number of image partitions                      |
 | image.bolt.file         | IMAGE_BOLT_FILE         | `/var/pictures.db`       | images bolt file location                       |
-| image.resize-width      | IMAGE_RESIZE_WIDTH      | `1600`                   | width of resized image                          |
-| image.resize-height     | IMAGE_RESIZE_HEIGHT     | `600`                    | height of resized image                         |
+| image.resize-width      | IMAGE_RESIZE_WIDTH      | `2400`                   | width of resized image                          |
+| image.resize-height     | IMAGE_RESIZE_HEIGHT     | `900`                    | height of resized image                         |
 | auth.ttl.jwt            | AUTH_TTL_JWT            | `5m`                     | jwt TTL                                         |
 | auth.ttl.cookie         | AUTH_TTL_COOKIE         | `200h`                   | cookie TTL                                      |
 | auth.google.cid         | AUTH_GOOGLE_CID         |                          | Google OAuth client ID                          |

--- a/README.md
+++ b/README.md
@@ -127,8 +127,8 @@ _this is the recommended way to run remark42_
 | image.fs.staging        | IMAGE_FS_STAGING        | `./var/pictures.staging` | staging location of images                      |
 | image.fs.partitions     | IMAGE_FS_PARTITIONS     | `100`                    | number of image partitions                      |
 | image.bolt.file         | IMAGE_BOLT_FILE         | `/var/pictures.db`       | images bolt file location                       |
-| image.resize-width      | IMAGE_RESIZE_WIDTH      | `800`                    | width of resized image                          |
-| image.resize-height     | IMAGE_RESIZE_HEIGHT     | `300`                    | height of resized image                         |
+| image.resize-width      | IMAGE_RESIZE_WIDTH      | `1600`                   | width of resized image                          |
+| image.resize-height     | IMAGE_RESIZE_HEIGHT     | `600`                    | height of resized image                         |
 | auth.ttl.jwt            | AUTH_TTL_JWT            | `5m`                     | jwt TTL                                         |
 | auth.ttl.cookie         | AUTH_TTL_COOKIE         | `200h`                   | cookie TTL                                      |
 | auth.google.cid         | AUTH_GOOGLE_CID         |                          | Google OAuth client ID                          |

--- a/backend/app/cmd/server.go
+++ b/backend/app/cmd/server.go
@@ -131,8 +131,8 @@ type ImageGroup struct {
 		File string `long:"file" env:"FILE" default:"./var/pictures.db" description:"images bolt file location"`
 	} `group:"bolt" namespace:"bolt" env-namespace:"bolt"`
 	MaxSize      int `long:"max-size" env:"MAX_SIZE" default:"5000000" description:"max size of image file"`
-	ResizeWidth  int `long:"resize-width" env:"RESIZE_WIDTH" default:"1600" description:"width of resized image"`
-	ResizeHeight int `long:"resize-height" env:"RESIZE_HEIGHT" default:"600" description:"height of resized image"`
+	ResizeWidth  int `long:"resize-width" env:"RESIZE_WIDTH" default:"2400" description:"width of resized image"`
+	ResizeHeight int `long:"resize-height" env:"RESIZE_HEIGHT" default:"900" description:"height of resized image"`
 }
 
 // AvatarGroup defines options group for avatar params

--- a/backend/app/cmd/server.go
+++ b/backend/app/cmd/server.go
@@ -131,8 +131,8 @@ type ImageGroup struct {
 		File string `long:"file" env:"FILE" default:"./var/pictures.db" description:"images bolt file location"`
 	} `group:"bolt" namespace:"bolt" env-namespace:"bolt"`
 	MaxSize      int `long:"max-size" env:"MAX_SIZE" default:"5000000" description:"max size of image file"`
-	ResizeWidth  int `long:"resize-width" env:"RESIZE_WIDTH" default:"800" description:"width of resized image"`
-	ResizeHeight int `long:"resize-height" env:"RESIZE_HEIGHT" default:"300" description:"height of resized image"`
+	ResizeWidth  int `long:"resize-width" env:"RESIZE_WIDTH" default:"1600" description:"width of resized image"`
+	ResizeHeight int `long:"resize-height" env:"RESIZE_HEIGHT" default:"600" description:"height of resized image"`
 }
 
 // AvatarGroup defines options group for avatar params


### PR DESCRIPTION
- Fixed "Improve quality of images #488" (sharp vibrant awesome images)
- Added retina display support
- Support for 3x devices including 11 Pro and MacPro
- Resources usage is good as was for scaled images (change is subtle after scaling), example for big image is 180 KB and 298 KB.

## Example
<img width="865" alt="Screen Shot 2020-01-04 at 11 03 45 PM" src="https://user-images.githubusercontent.com/1043549/71771123-4f6dc980-2f47-11ea-8f54-1486096dedda.png">
