### PR TITLE
Remove build of frontend from test job

### DIFF
--- a/.github/workflows/ci-test-frontend.yml
+++ b/.github/workflows/ci-test-frontend.yml
@@ -24,8 +24,5 @@ jobs:
       - run: npm ci
         working-directory: ./frontend
 
-      - run: npx run-p check lint test build
-        working-directory: ./frontend
-
-      - run: npm run build
+      - run: npx run-p check lint test
         working-directory: ./frontend


### PR DESCRIPTION
I realized that now we run frontend build twice in test job and for the third time we run it in docker.
I removed all that runs from test job.