### PR TITLE
check user equality for email notifications only by ID instead of complete object

### DIFF
--- a/backend/app/notify/email.go
+++ b/backend/app/notify/email.go
@@ -195,7 +195,7 @@ func (e *Email) Send(ctx context.Context, req Request) (err error) {
 	}
 
 	if req.Comment.ID != "" {
-		if req.parent.User == req.Comment.User {
+		if req.parent.User.ID == req.Comment.User.ID {
 			// don't send anything if if user replied to their own comment
 			return nil
 		}

--- a/backend/app/notify/email_test.go
+++ b/backend/app/notify/email_test.go
@@ -187,8 +187,8 @@ func TestEmail_Send(t *testing.T) {
 	email.TokenGenFn = TokenGenFn
 	email.UnsubscribeURL = "https://remark42.com/api/v1/email/unsubscribe"
 	req := Request{
-		Comment: store.Comment{ID: "999", User: store.User{Name: "test_user"}, PostTitle: "test_title"},
-		parent:  store.Comment{ID: "1", User: store.User{Name: "parent_user"}},
+		Comment: store.Comment{ID: "999", User: store.User{ID: "1", Name: "test_user"}, PostTitle: "test_title"},
+		parent:  store.Comment{ID: "1", User: store.User{ID: "999", Name: "parent_user"}},
 		Email:   "test@example.org"}
 	assert.NoError(t, email.Send(context.TODO(), req))
 	assert.Equal(t, "from@example.org", fakeSmtp.readMail())


### PR DESCRIPTION
$subj, bug discovered during #537 tests: user I've used for test got email notification for reply to his own comment.