### PR TITLE
Fix position of "show more" button

### DIFF
--- a/frontend/app/components/root/__show-more/root__show-more.scss
+++ b/frontend/app/components/root/__show-more/root__show-more.scss
@@ -1,4 +1,5 @@
 .root__show-more {
+  display: block;
   width: 300px;
   max-width: 100%;
   margin: 20px auto;


### PR DESCRIPTION
It was aligned by the left side.
This button visible only on mobile version.