### PR TITLE
Drop cache on release for remark.css/.js

### DIFF
--- a/frontend/iframe.html
+++ b/frontend/iframe.html
@@ -10,7 +10,6 @@
         window.close();
       }
     </script>
-    <link rel="stylesheet" href="remark.css" />
     <style>
       html,
       body {
@@ -127,6 +126,5 @@
 
       window.parent.postMessage(JSON.stringify({ inited: true }), '*');
     </script>
-    <script type="text/javascript" src="remark.js"></script>
   </body>
 </html>

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -165,7 +165,7 @@ module.exports = () => ({
       inject: false,
     }),
     new MiniCssExtractPlugin({
-      filename: '[name].css',
+      filename: '[name].css?[contenthash:6]',
     }),
     new webpack.optimize.ModuleConcatenationPlugin(),
     ...(process.env.CI

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -70,8 +70,8 @@ module.exports = () => ({
   },
   output: {
     path: publicFolder,
-    filename: `[name].js`,
-    chunkFilename: '[name].js',
+    filename: `[name].js?[contenthash:6]`,
+    chunkFilename: '[name].js?[contenthash:6]',
   },
   resolve: {
     extensions: ['.tsx', '.ts', '.jsx', '.js'],
@@ -140,7 +140,13 @@ module.exports = () => ({
       'process.env.REMARK_URL': env === 'production' ? JSON.stringify(remarkUrl) : 'window.location.origin',
     }),
     new Html({
+      template: path.resolve(__dirname, 'iframe.html'),
+      filename: 'iframe.html',
+      chunks: ['remark'],
+    }),
+    new Html({
       template: path.resolve(__dirname, 'index.ejs'),
+      filename: 'index.html',
       inject: false,
     }),
     new Html({
@@ -174,7 +180,7 @@ module.exports = () => ({
             openAnalyzer: false,
           }),
         ]),
-    new Copy(['./iframe.html', './deleteme.html', './markdown-help.html']),
+    new Copy(['./deleteme.html', './markdown-help.html']),
   ],
   watchOptions: {
     ignored: /(node_modules|\.vendor\.js$)/,


### PR DESCRIPTION
Now static files load by permanent link it may cause problems with caching.
I added dynamic query string to loaded files, it generates by a content hash of the files and flush cache only when the content of the file was updated.

<details>
<summary>Hashes in url were added</summary>

<img width="1162" alt="Screenshot 2020-01-16 at 09 57 49" src="https://user-images.githubusercontent.com/2330682/72501042-f1928900-3846-11ea-943f-3d9a96b37ee1.png">

</details> 