### PR TITLE
Fix free space under comments if is opened by link

### DIFF
--- a/frontend/app/components/comment/_replying/comment_replying.scss
+++ b/frontend/app/components/comment/_replying/comment_replying.scss
@@ -1,4 +1,6 @@
 .comment_replying {
+  padding-bottom: 0;
+
   .comment__score {
     top: 4px;
     right: 0;
@@ -7,7 +9,6 @@
   /* it isn't mobile first, but it's fine here */
   @media (-moz-touch-enabled: 1) and (max-width: 768px), (pointer: coarse) and (max-width: 768px) {
     border: 8px solid;
-    padding-bottom: 0;
 
     .comment__body {
       padding: 8px 8px 0;

--- a/frontend/app/components/comment/comment.scss
+++ b/frontend/app/components/comment/comment.scss
@@ -19,3 +19,7 @@
     padding-left: 0;
   }
 }
+
+.comment-form_type_reply {
+  margin-left: 17px;
+}

--- a/frontend/app/components/thread/__collapse/thread__collapse.scss
+++ b/frontend/app/components/thread/__collapse/thread__collapse.scss
@@ -1,5 +1,5 @@
 .thread__collapse {
-  height: 100%;
+  height: calc(100% - 50px);
   width: 11px;
   position: absolute;
   top: 50px;


### PR DESCRIPTION
1. If you open this link you can see that avatars on previous comments are hidden, and free space under comments appeared.
https://radio-t.com/p/2020/01/07/prep-684/#remark42__comment-4e913b7e-bbd2-4b7b-9d79-7f81fd217a5e

<details>
<summary>Screenshot</summary>

<img width="764" alt="Screenshot 2020-01-16 at 22 30 11" src="https://user-images.githubusercontent.com/2330682/72556576-f8a1b180-38af-11ea-9671-16c04028b700.png">
</details>

2. If you reply to any comment collapser crosses comment form. 

<details>
<summary>Bug</summary>

<img width="727" alt="Screenshot 2020-01-16 at 22 36 45" src="https://user-images.githubusercontent.com/2330682/72557178-44a12600-38b1-11ea-8167-bd9c905f5c8f.png">

</details>

<details>
<summary>Fix</summary>

<img width="728" alt="Screenshot 2020-01-16 at 22 38 05" src="https://user-images.githubusercontent.com/2330682/72557189-51257e80-38b1-11ea-80a9-184abdb66c60.png">
</details>
