### PR TITLE
Lower Cache-Control max-age from 24h to 1h 

### DIFF
--- a/backend/app/rest/api/rest.go
+++ b/backend/app/rest/api/rest.go
@@ -469,7 +469,7 @@ func addFileServer(r chi.Router, path string, root http.FileSystem, version stri
 
 	r.With(tollbooth_chi.LimitHandler(tollbooth.NewLimiter(20, nil)),
 		middleware.Timeout(10*time.Second),
-		cacheControl(time.Hour*24, version),
+		cacheControl(time.Hour, version),
 	).Get(path, func(w http.ResponseWriter, r *http.Request) {
 		// don't show dirs, just serve files
 		if strings.HasSuffix(r.URL.Path, "/") && len(r.URL.Path) > 1 && r.URL.Path != (origPath+"/") {


### PR DESCRIPTION
This change increase the speed of updates delivery to one hour, targeting #556.

If we don't have a unique path for static resources per version of remark, we want Cache-Control max-age to be set as low as reasonably possible.