### PR TITLE
Add subscription link support to notification email verification template

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,6 @@ _this is the recommended way to run remark42_
 | notify.telegram.timeout | NOTIFY_TELEGRAM_TIMEOUT | `5s`                     | telegram timeout                                |
 | notify.email.fromAddress | NOTIFY_EMAIL_FROM      |                          | from email address                              |
 | notify.email.verification_subj | NOTIFY_EMAIL_VERIFICATION_SUBJ | `Email verification` | verification message subject          |
-| notify.email.subscribe-url | NOTIFY_EMAIL_SUBSCRIBE_URL | `` | URL parameters to add to SITE in order to include to subscription email instead of plain token |
 | smtp.host               | SMTP_HOST               |                          | SMTP host                                       |
 | smtp.port               | SMTP_PORT               |                          | SMTP port                                       |
 | smtp.username           | SMTP_USERNAME           |                          | SMTP user name                                  |

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ _this is the recommended way to run remark42_
 | notify.telegram.timeout | NOTIFY_TELEGRAM_TIMEOUT | `5s`                     | telegram timeout                                |
 | notify.email.fromAddress | NOTIFY_EMAIL_FROM      |                          | from email address                              |
 | notify.email.verification_subj | NOTIFY_EMAIL_VERIFICATION_SUBJ | `Email verification` | verification message subject          |
+| notify.email.subscribe-url | NOTIFY_EMAIL_SUBSCRIBE_URL | `` | URL parameters to add to SITE in order to include to subscription email instead of plain token |
 | smtp.host               | SMTP_HOST               |                          | SMTP host                                       |
 | smtp.port               | SMTP_PORT               |                          | SMTP port                                       |
 | smtp.username           | SMTP_USERNAME           |                          | SMTP user name                                  |

--- a/backend/app/cmd/server.go
+++ b/backend/app/cmd/server.go
@@ -199,6 +199,7 @@ type NotifyGroup struct {
 	Email struct {
 		From                string `long:"fromAddress" env:"FROM" description:"from email address"`
 		VerificationSubject string `long:"verification_subj" env:"VERIFICATION_SUBJ" description:"verification message subject"`
+		SubscribeURL        string `long:"subscribe-url" env:"SUBSCRIBE_URL" description:"URL parameters to add to SITE in order to include to subscription email instead of plain token"`
 	} `group:"email" namespace:"email" env-namespace:"EMAIL"`
 }
 
@@ -782,6 +783,9 @@ func (s *ServerCommand) makeNotify(dataStore *service.DataStore, authenticator *
 					}
 					return tkn, nil
 				},
+			}
+			if s.Notify.Email.SubscribeURL != "" {
+				emailParams.SubscribeURL = s.RemarkURL + s.Notify.Email.SubscribeURL
 			}
 			smtpParams := notify.SmtpParams{
 				Host:     s.SMTP.Host,

--- a/backend/app/cmd/server.go
+++ b/backend/app/cmd/server.go
@@ -199,7 +199,6 @@ type NotifyGroup struct {
 	Email struct {
 		From                string `long:"fromAddress" env:"FROM" description:"from email address"`
 		VerificationSubject string `long:"verification_subj" env:"VERIFICATION_SUBJ" description:"verification message subject"`
-		SubscribeURL        string `long:"subscribe-url" env:"SUBSCRIBE_URL" description:"URL parameters to add to SITE in order to include to subscription email instead of plain token"`
 	} `group:"email" namespace:"email" env-namespace:"EMAIL"`
 }
 
@@ -767,6 +766,8 @@ func (s *ServerCommand) makeNotify(dataStore *service.DataStore, authenticator *
 				From:                s.Notify.Email.From,
 				VerificationSubject: s.Notify.Email.VerificationSubject,
 				UnsubscribeURL:      s.RemarkURL + "/email/unsubscribe.html",
+				// TODO: uncomment after #560 frontend part is ready and URL is known
+				//SubscribeURL:        s.RemarkURL + "/subscribe.html?token=",
 				TokenGenFn: func(userID, email, site string) (string, error) {
 					claims := token.Claims{
 						Handshake: &token.Handshake{ID: userID + "::" + email},
@@ -783,9 +784,6 @@ func (s *ServerCommand) makeNotify(dataStore *service.DataStore, authenticator *
 					}
 					return tkn, nil
 				},
-			}
-			if s.Notify.Email.SubscribeURL != "" {
-				emailParams.SubscribeURL = s.RemarkURL + s.Notify.Email.SubscribeURL
 			}
 			smtpParams := notify.SmtpParams{
 				Host:     s.SMTP.Host,

--- a/backend/app/notify/email.go
+++ b/backend/app/notify/email.go
@@ -23,6 +23,7 @@ type EmailParams struct {
 	MsgTemplate          string // request message template
 	VerificationSubject  string // verification message subject
 	VerificationTemplate string // verification message template
+	SubscribeURL         string // full subscribe handler URL
 	UnsubscribeURL       string // full unsubscribe handler URL
 
 	TokenGenFn func(userID, email, site string) (string, error) // Unsubscribe token generation function
@@ -91,10 +92,11 @@ type msgTmplData struct {
 
 // verifyTmplData store data for verification message template execution
 type verifyTmplData struct {
-	User  string
-	Token string
-	Email string
-	Site  string
+	User         string
+	Token        string
+	Email        string
+	Site         string
+	SubscribeURL string
 }
 
 const (
@@ -178,11 +180,15 @@ const (
 	<div style="text-align: center; font-family: Helvetica, Arial, sans-serif; font-size: 18px;">
 		<h1 style="position: relative; color: #4fbbd6; margin-top: 0.2em;">Remark42</h1>
 		<p style="position: relative; max-width: 20em; margin: 0 auto 1em auto; line-height: 1.4em; color:#000!important;">Confirmation for <b>{{.User}}</b> on site <b>{{.Site}}</b></p>
+		{{if .SubscribeURL}}
+		<p style="position: relative; margin: 0 0 0.5em 0;color:#000!important;"><a href="{{.SubscribeURL}}{{.Token}}">Click here to subscribe to email notifications</a></p>
+		{{ else }}
 		<div style="background-color: #eee; max-width: 20em; margin: 0 auto; border-radius: 0.4em; padding: 0.5em;">
 			<p style="position: relative; margin: 0 0 0.5em 0;color:#000!important;">TOKEN</p>
 			<p style="position: relative; font-size: 0.7em; opacity: 0.8;"><i style="color:#000!important;">Copy and paste this text into “token” field on comments page</i></p>
 			<p style="position: relative; font-family: monospace; background-color: #fff; margin: 0; padding: 0.5em; word-break: break-all; text-align: left; border-radius: 0.2em; -webkit-user-select: all; user-select: all;">{{.Token}}</p>
 		</div>
+		{{ end }}
 		<p style="position: relative; margin-top: 2em; font-size: 0.8em; opacity: 0.8;"><i style="color:#000!important;">Sent to {{.Email}}</i></p>
 	</div>
 </body>
@@ -273,10 +279,11 @@ func (e *Email) buildVerificationMessage(user, email, token, site string) (strin
 	subject := e.VerificationSubject
 	msg := bytes.Buffer{}
 	err := e.verifyTmpl.Execute(&msg, verifyTmplData{
-		User:  user,
-		Token: token,
-		Email: email,
-		Site:  site,
+		User:         user,
+		Token:        token,
+		Email:        email,
+		Site:         site,
+		SubscribeURL: e.SubscribeURL,
 	})
 	if err != nil {
 		return "", errors.Wrapf(err, "error executing template to build verification message")

--- a/backend/app/notify/email.go
+++ b/backend/app/notify/email.go
@@ -182,13 +182,13 @@ const (
 		<p style="position: relative; max-width: 20em; margin: 0 auto 1em auto; line-height: 1.4em; color:#000!important;">Confirmation for <b>{{.User}}</b> on site <b>{{.Site}}</b></p>
 		{{if .SubscribeURL}}
 		<p style="position: relative; margin: 0 0 0.5em 0;color:#000!important;"><a href="{{.SubscribeURL}}{{.Token}}">Click here to subscribe to email notifications</a></p>
-		{{ else }}
+		<p style="position: relative; margin: 0 0 0.5em 0;color:#000!important;">Alternatively, you can use code below for subscription.</p>
+		{{ end }}
 		<div style="background-color: #eee; max-width: 20em; margin: 0 auto; border-radius: 0.4em; padding: 0.5em;">
 			<p style="position: relative; margin: 0 0 0.5em 0;color:#000!important;">TOKEN</p>
 			<p style="position: relative; font-size: 0.7em; opacity: 0.8;"><i style="color:#000!important;">Copy and paste this text into “token” field on comments page</i></p>
 			<p style="position: relative; font-family: monospace; background-color: #fff; margin: 0; padding: 0.5em; word-break: break-all; text-align: left; border-radius: 0.2em; -webkit-user-select: all; user-select: all;">{{.Token}}</p>
 		</div>
-		{{ end }}
 		<p style="position: relative; margin-top: 2em; font-size: 0.8em; opacity: 0.8;"><i style="color:#000!important;">Sent to {{.Email}}</i></p>
 	</div>
 </body>


### PR DESCRIPTION
Address #560, the backend part.

When `NOTIFY_EMAIL_SUBSCRIBE_URL` environment variable is provided, instead of embedding token to email it will be included as a link.

With `SITE=http://127.0.0.1` and `NOTIFY_EMAIL_SUBSCRIBE_URL=/subscribe?token=`, link will look like `http://127.0.0.1/subscribe?token=<subscription_token>`. The token is not escaped and I'll escape it if it will be necessary when the frontend part will be written.

After the frontend counterpart will be created, `NOTIFY_EMAIL_SUBSCRIBE_URL` default should be set to newly created URL location.

That's how verification email looks like when subscribe_url is supplied:

<img width="326" alt="image" src="https://user-images.githubusercontent.com/712534/72687314-ec5e6400-3afc-11ea-9a29-5f1084065311.png">
