### PR TITLE
fix name line break and add styles for blockquote

### DIFF
--- a/backend/app/notify/email.go
+++ b/backend/app/notify/email.go
@@ -122,6 +122,11 @@ const (
 		p {
 			margin: 0 0 12px;
 		}
+		blockquote {
+			margin: 10px 0;
+			padding: 12px 12px 1px 12px;
+			background: rgba(255,255,255,.5)
+		}
 	</style>
 </head>
 <!-- Some of blocks on this page have color: #000 because GMail can wrap block in his own tags which can change text color -->
@@ -130,40 +135,31 @@ const (
 		<h1 style="text-align: center; position: relative; color: #4fbbd6; margin-top: 10px; margin-bottom: 10px;">Remark42</h1>
 		<div style="font-size: 16px; text-align: center; margin-bottom: 10px; color:#000!important;">New reply from {{.UserName}} on your comment{{if .PostTitle}} to «{{.PostTitle}}»{{ end }}</div>
 		<div style="background-color: #eee; padding: 15px 20px 20px 20px; border-radius: 3px;">
-			<div>
-				<div style="margin-bottom: 12px; line-height: 24px;">
-					<img src="{{.ParentUserPicture}}" style="width: 24px; height: 24px; float: left; margin: 0 8px 0 0; border-radius: 3px; background-color: #ccc;"/>
-					<span style="font-size: 14px; font-weight: bold; color: #777">{{.ParentUserName}}</span>
-					<span style="color: #999; font-size: 14px; margin: 0 8px;">{{.ParentCommentDate.Format "02.01.2006 at 15:04"}}</span>
-					<a href="{{.ParentCommentLink}}" style="color: #0aa; font-size: 14px;"><b>Show</b></a>
-				</div>
-				<div style="font-size: 14px; color:#333!important; padding: 0 14px 0 2px; border-radius: 3px; line-height: 1.4;">
-					{{.ParentCommentText}}
-				</div>
+			<div style="margin-bottom: 12px; line-height: 24px; word-break: break-all;">
+				<img src="{{.ParentUserPicture}}" style="width: 24px; height: 24px; display: inline; vertical-align: middle; margin: 0 8px 0 0; border-radius: 3px; background-color: #ccc;"/>
+				<span style="font-size: 14px; font-weight: bold; color: #777">{{.ParentUserName}}</span>
+				<span style="color: #999; font-size: 14px; margin: 0 8px;">{{.ParentCommentDate.Format "02.01.2006 at 15:04"}}</span>
+				<a href="{{.ParentCommentLink}}" style="color: #0aa; font-size: 14px;"><b>Show</b></a>
 			</div>
-			<div style="padding-left: 20px; border-left: 1px dotted rgba(0,0,0,0.15); margin-top: 15px; padding-top: 5px; line-height: 24px;">
-				<div style="margin-bottom: 8px;">
-					<img src="{{.UserPicture}}" style="width: 24px; height: 24px; float: left; margin: 0 8px 0 0; border-radius: 3px; background-color: #ccc;"/>
-					<div style="float: left; font-size: 14px; font-weight: bold; color: #777">
-						{{.UserName}}
-					</div>
-					<div style="color: #999; font-size: 14px; margin: 0 8px; float: left;">
-						{{.CommentDate.Format "02.01.2006 at 15:04"}}
-					</div>
+			<div style="font-size: 14px; color:#333!important; padding: 0 14px 0 2px; border-radius: 3px; line-height: 1.4;">
+				{{.ParentCommentText}}
+			</div>
+			<div style="padding-left: 20px; border-left: 1px dotted rgba(0,0,0,0.15); margin-top: 15px; padding-top: 5px;">
+				<div style="margin-bottom: 12px;" line-height: 24px;word-break: break-all;>
+					<img src="{{.UserPicture}}" style="width: 24px; height: 24px; display:inline; vertical-align:middle; margin: 0 8px 0 0; border-radius: 3px; background-color: #ccc;"/>
+					<span style="font-size: 14px; font-weight: bold; color: #777">{{.UserName}}</span>
+					<span style="color: #999; font-size: 14px; margin: 0 8px;">{{.CommentDate.Format "02.01.2006 at 15:04"}}</span>
 					<a href="{{.CommentLink}}" style="color: #0aa; font-size: 14px;"><b>Reply</b></a>
 				</div>
-				<div style="font-size: 16px; background-color: #fff; color:#000!important; padding: 14px 14px 2px 14px; border-radius: 3px; line-height: 1.4;">
-					{{.CommentText}}
-				</div>
+				<div style="font-size: 16px; background-color: #fff; color:#000!important; padding: 14px 14px 2px 14px; border-radius: 3px; line-height: 1.4;">{{.CommentText}}</div>
 			</div>
 		</div>
 		<div style="text-align: center; font-size: 14px; margin-top: 32px;">
 			<i style="color: #000!important;">Sent to <a style="color:inherit; text-decoration: none" href="mailto:{{.Email}}">{{.Email}}</a> for {{.ParentUserName}}</i>
-			<div style="margin: auto; width: 150px; border-top: 1px solid rgba(0, 0, 0, 0.15); padding-top: 15px; margin-top: 15px;">
-				<a style="color: #0aa;" href="{{.UnsubscribeLink}}">Unsubscribe</a>
-				<!-- This is hack for remove collapser in Gmail which can collapse end of the message -->
-				<div style="opacity: 0;">[{{.CommentDate.Format "02.01.2006 at 15:04"}}]</div>
-			</div>
+			<div style="margin: auto; width: 150px; border-top: 1px solid rgba(0, 0, 0, 0.15); padding-top: 15px; margin-top: 15px;"></div>
+			<a style="color: #0aa;" href="{{.UnsubscribeLink}}">Unsubscribe</a>
+			<!-- This is hack for remove collapser in Gmail which can collapse end of the message -->
+			<div style="opacity: 0;font-size: 1;">[{{.CommentDate.Format "02.01.2006 at 15:04"}}]</div>
 		</div>
 	</div>
 </body>


### PR DESCRIPTION
#577 

<details>
<summary>Bug</summary>

![IMAGE 2020-01-23 11:30:20](https://user-images.githubusercontent.com/2330682/73035970-07153d80-3e5b-11ea-9e29-6dc9ea8cb524.jpg)
</details>

<details>
<summary>Fix</summary>

![Screenshot 2020-01-24 at 03 21 19](https://user-images.githubusercontent.com/2330682/73035988-11cfd280-3e5b-11ea-8d11-bc854843bddd.png)
</details>

<details>
<summary>Blockquote</summary>


Styling for blockquote was added but it will not be styled for a reply because it is already on a white background

![Screenshot 2020-01-24 at 03 20 24](https://user-images.githubusercontent.com/2330682/73036115-78ed8700-3e5b-11ea-80f8-ae2067635f8c.png)

</details>

