### PR TITLE
Simpler image service

### DIFF
--- a/backend/app/rest/proxy/image.go
+++ b/backend/app/rest/proxy/image.go
@@ -186,8 +186,7 @@ func (p Image) downloadImage(ctx context.Context, imgURL string) (io.ReadCloser,
 		return e
 	})
 	if err != nil {
-		log.Print(err.Error())
-		return nil, err
+		return nil, errors.Wrapf(err, "can't download image %s", imgURL)
 	}
 
 	if resp.StatusCode != http.StatusOK {

--- a/backend/app/rest/proxy/image.go
+++ b/backend/app/rest/proxy/image.go
@@ -159,10 +159,7 @@ func (p Image) cacheImage(r io.Reader, imgID string) {
 	if err != nil {
 		log.Printf("[WARN] unable to save image to the storage: %+v", err)
 	}
-	// In the future we can do something smarter than just committing everything (eg, some kind of LFU/LRU)
-	if err := p.ImageService.Commit(id); err != nil {
-		log.Printf("[WARN] unable to commit image %s", imgID)
-	}
+	p.ImageService.Submit(func() []string { return []string{id} })
 }
 
 // download an image. Returns a Reader which has to be closed by a caller

--- a/backend/app/rest/proxy/image_test.go
+++ b/backend/app/rest/proxy/image_test.go
@@ -114,7 +114,7 @@ func TestImage_Routes_CachingImage(t *testing.T) {
 
 	imageStore.On("Load", mock.Anything).Once().Return(nil, int64(0), nil)
 	imageStore.On("SaveWithID", mock.Anything, mock.Anything).Once().Run(func(args mock.Arguments) { _, _ = ioutil.ReadAll(args.Get(1).(io.Reader)) }).Return("", nil)
-	imageStore.On("Commit", mock.Anything).Once().Return(nil)
+	imageStore.On("commit", mock.Anything).Once().Return(nil)
 
 	resp, err := http.Get(ts.URL + "/?src=" + encodedImgURL)
 	require.Nil(t, err)
@@ -124,7 +124,7 @@ func TestImage_Routes_CachingImage(t *testing.T) {
 
 	imageStore.AssertCalled(t, "Load", mock.Anything)
 	imageStore.AssertCalled(t, "SaveWithID", "cached_images/4b84b15bff6ee5796152495a230e45e3d7e947d9-"+sha1Str(imgURL), mock.Anything)
-	imageStore.AssertCalled(t, "Commit", mock.Anything)
+	imageStore.AssertCalled(t, "commit", mock.Anything)
 }
 
 func TestImage_Routes_Using_Cachded_Image(t *testing.T) {

--- a/backend/app/store/image/bolt_store_test.go
+++ b/backend/app/store/image/bolt_store_test.go
@@ -31,7 +31,7 @@ func TestBoltStore_SaveCommit(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	err = svc.Commit(id)
+	err = svc.commit(id)
 	require.NoError(t, err)
 
 	err = svc.db.View(func(tx *bolt.Tx) error {
@@ -90,7 +90,7 @@ func TestBoltStore_Cleanup(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 	img3 := save("blah_ff3.png", "user2")
 
-	err := svc.Cleanup(context.Background(), time.Since(img1ts)) // clean first images
+	err := svc.cleanup(context.Background(), time.Since(img1ts)) // clean first images
 	assert.NoError(t, err)
 
 	assertBoltImgNil(t, svc.db, imagesStagedBktName, img1)
@@ -98,10 +98,10 @@ func TestBoltStore_Cleanup(t *testing.T) {
 	assertBoltImgNotNil(t, svc.db, imagesStagedBktName, img2)
 	assertBoltImgNotNil(t, svc.db, imagesStagedBktName, img3)
 
-	err = svc.Commit(img3)
+	err = svc.commit(img3)
 	require.NoError(t, err)
 
-	err = svc.Cleanup(context.Background(), time.Millisecond*10)
+	err = svc.cleanup(context.Background(), time.Millisecond*10)
 	assert.NoError(t, err)
 
 	assertBoltImgNil(t, svc.db, imagesStagedBktName, img2)

--- a/backend/app/store/image/fs_store.go
+++ b/backend/app/store/image/fs_store.go
@@ -36,7 +36,7 @@ type FileSystem struct {
 	}
 }
 
-// SaveWithID saves data from reader with given id
+// SaveWithID saves data from a reader, with given id
 func (f *FileSystem) SaveWithID(id string, r io.Reader) (string, error) {
 	data, err := readAndValidateImage(r, f.MaxSize)
 	if err != nil {
@@ -51,15 +51,15 @@ func (f *FileSystem) SaveWithID(id string, r io.Reader) (string, error) {
 	}
 
 	if err = ioutil.WriteFile(dst, data, 0600); err != nil {
-		return "", errors.Wrapf(err, "can't write file")
+		return "", errors.Wrapf(err, "can't write image file")
 	}
 
 	log.Printf("[DEBUG] file %s saved for image %s, size=%d", dst, id, len(data))
 	return id, nil
 }
 
-// Save data from reader for given file name to local FS, staging directory. Returns id as user/uuid
-// Files partitioned across multiple subdirectories and the final path includes part, i.e. /location/user1/03/123-4567
+// Save data from a reader for given file name to local FS, staging directory. Returns id as user/uuid
+// Files partitioned across multiple subdirectories, and the final path includes part, i.e. /location/user1/03/123-4567
 func (f *FileSystem) Save(fileName string, userID string, r io.Reader) (id string, err error) {
 	id = path.Join(userID, guid()) // make id as user/uuid
 	finalID, err := f.SaveWithID(id, r)
@@ -70,7 +70,7 @@ func (f *FileSystem) Save(fileName string, userID string, r io.Reader) (id strin
 }
 
 // Commit file stored in staging location by moving it to permanent location
-func (f *FileSystem) Commit(id string) error {
+func (f *FileSystem) commit(id string) error {
 	log.Printf("[DEBUG] commit image %s", id)
 	stagingImage, permImage := f.location(f.Staging, id), f.location(f.Location, id)
 
@@ -110,7 +110,7 @@ func (f *FileSystem) Load(id string) (io.ReadCloser, int64, error) {
 }
 
 // Cleanup runs scan of staging and removes old files based on ttl
-func (f *FileSystem) Cleanup(ctx context.Context, ttl time.Duration) error {
+func (f *FileSystem) cleanup(_ context.Context, ttl time.Duration) error {
 
 	if _, err := os.Stat(f.Staging); os.IsNotExist(err) {
 		return nil

--- a/backend/app/store/image/fs_store.go
+++ b/backend/app/store/image/fs_store.go
@@ -125,7 +125,7 @@ func (f *FileSystem) cleanup(_ context.Context, ttl time.Duration) error {
 			return nil
 		}
 		age := time.Since(info.ModTime())
-		if age > ttl {
+		if age > (ttl + 100*time.Millisecond) { // delay cleanup triggering to allow commit
 			log.Printf("[INFO] remove staging image %s, age %v", fpath, age)
 			rmErr := os.Remove(fpath)
 			_ = os.Remove(path.Dir(fpath)) // try to remove directory

--- a/backend/app/store/image/fs_store.go
+++ b/backend/app/store/image/fs_store.go
@@ -51,7 +51,7 @@ func (f *FileSystem) SaveWithID(id string, r io.Reader) (string, error) {
 	}
 
 	if err = ioutil.WriteFile(dst, data, 0600); err != nil {
-		return "", errors.Wrapf(err, "can't write image file")
+		return "", errors.Wrapf(err, "can't write image file with id %s", id)
 	}
 
 	log.Printf("[DEBUG] file %s saved for image %s, size=%d", dst, id, len(data))
@@ -64,7 +64,7 @@ func (f *FileSystem) Save(fileName string, userID string, r io.Reader) (id strin
 	id = path.Join(userID, guid()) // make id as user/uuid
 	finalID, err := f.SaveWithID(id, r)
 	if err != nil {
-		err = errors.Wrapf(err, "can't save file %s", fileName)
+		err = errors.Wrapf(err, "can't save image file %s", fileName)
 	}
 	return finalID, err
 }
@@ -116,6 +116,7 @@ func (f *FileSystem) cleanup(_ context.Context, ttl time.Duration) error {
 		return nil
 	}
 
+	// we can ignore context as on local FS remove is relatively fast operation
 	err := filepath.Walk(f.Staging, func(fpath string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err

--- a/backend/app/store/image/fs_store.go
+++ b/backend/app/store/image/fs_store.go
@@ -61,12 +61,12 @@ func (f *FileSystem) SaveWithID(id string, r io.Reader) (string, error) {
 // Save data from a reader for given file name to local FS, staging directory. Returns id as user/uuid
 // Files partitioned across multiple subdirectories, and the final path includes part, i.e. /location/user1/03/123-4567
 func (f *FileSystem) Save(fileName string, userID string, r io.Reader) (id string, err error) {
-	id = path.Join(userID, guid()) // make id as user/uuid
-	finalID, err := f.SaveWithID(id, r)
+	tempId := path.Join(userID, guid()) // make id as user/uuid
+	id, err = f.SaveWithID(tempId, r)
 	if err != nil {
 		err = errors.Wrapf(err, "can't save image file %s", fileName)
 	}
-	return finalID, err
+	return id, err
 }
 
 // Commit file stored in staging location by moving it to permanent location

--- a/backend/app/store/image/fs_store_test.go
+++ b/backend/app/store/image/fs_store_test.go
@@ -259,7 +259,7 @@ func TestFsStore_Cleanup(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 	img3 := save("blah_ff3.png", "user2")
 
-	time.Sleep(100 * time.Millisecond) // make first image expired
+	time.Sleep(200 * time.Millisecond) // make first image expired
 	err := svc.cleanup(context.Background(), time.Millisecond*300)
 	assert.NoError(t, err)
 

--- a/backend/app/store/image/fs_store_test.go
+++ b/backend/app/store/image/fs_store_test.go
@@ -129,7 +129,7 @@ func TestFsStore_SaveAndCommit(t *testing.T) {
 
 	id, err := svc.Save("file1.png", "user1", gopherPNG())
 	require.NoError(t, err)
-	err = svc.Commit(id)
+	err = svc.commit(id)
 	require.NoError(t, err)
 
 	imgStaging := svc.location(svc.Staging, id)
@@ -180,7 +180,7 @@ func TestFsStore_LoadAfterCommit(t *testing.T) {
 	id, err := svc.Save("blah_ff1.png", "user1", gopherPNG())
 	assert.NoError(t, err)
 	t.Log(id)
-	err = svc.Commit(id)
+	err = svc.commit(id)
 	require.NoError(t, err)
 
 	r, sz, err := svc.Load(id)
@@ -260,7 +260,7 @@ func TestFsStore_Cleanup(t *testing.T) {
 	img3 := save("blah_ff3.png", "user2")
 
 	time.Sleep(100 * time.Millisecond) // make first image expired
-	err := svc.Cleanup(context.Background(), time.Millisecond*300)
+	err := svc.cleanup(context.Background(), time.Millisecond*300)
 	assert.NoError(t, err)
 
 	_, err = os.Stat(img1)
@@ -280,7 +280,7 @@ func TestFsStore_Cleanup(t *testing.T) {
 	assert.NoError(t, err, "file on staging")
 
 	time.Sleep(200 * time.Millisecond) // make all images expired
-	err = svc.Cleanup(context.Background(), time.Millisecond*300)
+	err = svc.cleanup(context.Background(), time.Millisecond*300)
 	assert.NoError(t, err)
 
 	_, err = os.Stat(img2)

--- a/backend/app/store/image/image.go
+++ b/backend/app/store/image/image.go
@@ -206,6 +206,12 @@ func isValidImage(b []byte) bool {
 }
 
 func readAndValidateImage(r io.Reader, maxSize int) ([]byte, error) {
+
+	isValidImage := func(b []byte) bool {
+		ct := http.DetectContentType(b)
+		return ct == "image/gif" || ct == "image/png" || ct == "image/jpeg" || ct == "image/webp"
+	}
+
 	lr := io.LimitReader(r, int64(maxSize)+1)
 	data, err := ioutil.ReadAll(lr)
 	if err != nil {

--- a/backend/app/store/image/image_mock.go
+++ b/backend/app/store/image/image_mock.go
@@ -16,34 +16,6 @@ type MockStore struct {
 	mock.Mock
 }
 
-// Cleanup provides a mock function with given fields: ctx, ttl
-func (_m *MockStore) Cleanup(ctx context.Context, ttl time.Duration) error {
-	ret := _m.Called(ctx, ttl)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, time.Duration) error); ok {
-		r0 = rf(ctx, ttl)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// Commit provides a mock function with given fields: id
-func (_m *MockStore) Commit(id string) error {
-	ret := _m.Called(id)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(string) error); ok {
-		r0 = rf(id)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
 // Load provides a mock function with given fields: id
 func (_m *MockStore) Load(id string) (io.ReadCloser, int64, error) {
 	ret := _m.Called(id)
@@ -125,6 +97,34 @@ func (_m *MockStore) SizeLimit() int {
 		r0 = rf()
 	} else {
 		r0 = ret.Get(0).(int)
+	}
+
+	return r0
+}
+
+// cleanup provides a mock function with given fields: ctx, ttl
+func (_m *MockStore) cleanup(ctx context.Context, ttl time.Duration) error {
+	ret := _m.Called(ctx, ttl)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, time.Duration) error); ok {
+		r0 = rf(ctx, ttl)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// commit provides a mock function with given fields: id
+func (_m *MockStore) commit(id string) error {
+	ret := _m.Called(id)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string) error); ok {
+		r0 = rf(id)
+	} else {
+		r0 = ret.Error(0)
 	}
 
 	return r0

--- a/backend/app/store/service/service_test.go
+++ b/backend/app/store/service/service_test.go
@@ -1277,7 +1277,7 @@ func TestService_submitImages(t *testing.T) {
 	lgr.Setup(lgr.Debug, lgr.CallerFile, lgr.CallerFunc)
 
 	mockStore := image.MockStore{}
-	mockStore.On("Commit", mock.Anything, mock.Anything).Times(2).Return(nil)
+	mockStore.On("commit", mock.Anything, mock.Anything).Times(2).Return(nil)
 	imgSvc := &image.Service{Store: &mockStore, TTL: time.Millisecond * 50}
 
 	// two comments for https://radio-t.com
@@ -1296,7 +1296,7 @@ func TestService_submitImages(t *testing.T) {
 	_, err := b.Engine.Create(c) // create directly with engine, doesn't call submitImages
 	assert.NoError(t, err)
 
-	b.submitImages(c)
+	b.submitImages(c.Locator, c.ID)
 	time.Sleep(250 * time.Millisecond)
 }
 


### PR DESCRIPTION
1. I have investigated the ability to add remote image store #572 and found the `image.Store` interface a little bit confusing. I have tried to make the intent as clear as possible and demoted internally used commit and cleanup to private methods.
1. replaced immediate commit (in rest/proxy) to delayed one via `Submit`.
1. fixed potential race inside `Close`
1. added some comment
1. minor refactoring

@smaant - pls take a look. Hopefully, it makes sense to you.

